### PR TITLE
Disabled Max/Min button in ThunderControlBox

### DIFF
--- a/src/ReaLTaiizor/Controls/ControlBox/ThunderControlBox.cs
+++ b/src/ReaLTaiizor/Controls/ControlBox/ThunderControlBox.cs
@@ -28,6 +28,28 @@ namespace ReaLTaiizor.Controls
             }
         }
 
+        private bool _EnableMaximize = false;
+        public bool EnableMaximizeButton
+        {
+            get => _EnableMaximize;
+            set
+            {
+                _EnableMaximize = value;
+                Invalidate();
+            }
+        }
+
+        private bool _EnableMinimize = false;
+        public bool EnableMinimizeButton
+        {
+            get => _EnableMinimize;
+            set
+            {
+                _EnableMinimize = value;
+                Invalidate();
+            }
+        }
+
         #endregion
 
         private MouseStateThunder State = MouseStateThunder.None;


### PR DESCRIPTION
Unlike other controls, you couldn't disable maximize/minimize button in ThunderControlBox. Now, you may have the option to disable the buttons.