### PR TITLE
CI: Fix CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: windows-2019 #windows-lates ubuntu-latest
+    runs-on: windows-2022
     permissions:
       actions: read
       contents: read
@@ -64,13 +64,10 @@ jobs:
         dotnet-version: 7.0.100-rc.1.22431.12
 
     - name: Restore the ReaLTaiizor
-      run: dotnet restore ${{ matrix.solution }} -p:Configuration=${{ matrix.configuration }} -p:UseSharedCompilation=true
+      run: dotnet restore ${{ matrix.solution }} -p:Configuration=${{ matrix.configuration }} -p:UseSharedCompilation=false
 
     - name: Build the ReaLTaiizor
-      run: dotnet build ${{ matrix.solution }} -c ${{ matrix.configuration }} -p:UseSharedCompilation=true --no-restore /nowarn:CS0067,CS0108,CS0109,CS0114,CS0169,CS0414,CS0618,CS0649,CS8632,CA1416,NU5104,NETSDK1138,SYSLIB0003
-
-    - name: Test the ReaLTaiizor
-      run: dotnet test ${{ matrix.solution }} -c ${{ matrix.configuration }} --no-build --verbosity normal
+      run: dotnet build ${{ matrix.solution }} -c ${{ matrix.configuration }} -p:UseSharedCompilation=false --no-restore /nowarn:CS0067,CS0108,CS0109,CS0114,CS0169,CS0414,CS0618,CS0649,CS8632,CA1416,NU5104,NETSDK1138,SYSLIB0003
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
This PR bundles together a few fixes to the CodeQL workflow that should get it working again:

1. Swap `windows-2019` workers for `windows-2022` ones, which have a newer version of dependencies that are needed for your build.
2. Swap `-p:UseSharedCompilation=true` for `-p:UseSharedCompilation=false`, which will allow CodeQL to observe your build process.
3. Remove the step that runs your tests, which CodeQL typically doesn't need to see.