### PR TITLE
BorderStyle property name of poison form conflicts with System.Window…

### DIFF
--- a/src/ReaLTaiizor/Forms/Form/PoisonForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/PoisonForm.cs
@@ -76,7 +76,8 @@ namespace ReaLTaiizor.Forms
         [DefaultValue(Enum.Poison.FormBorderStyle.None)]
         [Browsable(true)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
-        public Enum.Poison.FormBorderStyle BorderStyle { get; set; } = Enum.Poison.FormBorderStyle.None;
+        public Enum.Poison.FormBorderStyle PoisonBorderStyle { get; set; } = Enum.Poison.FormBorderStyle.None;
+
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
         public bool Movable { get; set; } = true;
 
@@ -299,7 +300,7 @@ namespace ReaLTaiizor.Forms
                 e.Graphics.FillRectangle(b, topRect);
             }
 
-            if (BorderStyle != Enum.Poison.FormBorderStyle.None)
+            if (PoisonBorderStyle != Enum.Poison.FormBorderStyle.None)
             {
                 Color c = PoisonPaint.BorderColor.Form(Theme);
 


### PR DESCRIPTION
BorderStyle property name of poison form conflicts with System.Windows.Forms.BorderSytle on PoisonDataGrid. 
Everytime you design some property on PoisonDataGrid, it gives error on InitializeComponent method.  Please see Form20 to produce the error. Open the grid on design form; and you'll see the error.  In order to fix this. name change was required on Enum.Posion.BorderStyle