### PR TITLE
Fixed the error where 'PoisonTextBox.ContextMenuStrip' attribute cannot be used properly

### DIFF
--- a/src/ReaLTaiizor/Controls/TextBox/PoisonTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/PoisonTextBox.cs
@@ -335,7 +335,6 @@ namespace ReaLTaiizor.Controls
             get => baseTextBox.ContextMenuStrip;
             set
             {
-                ContextMenuStrip = value;
                 baseTextBox.ContextMenuStrip = value;
             }
         }


### PR DESCRIPTION
*I used machine translation, which may make the article look strange. Please forgive me* 


\
When I use this attribute and start debugging, an error will be reported in this attribute`System.StackOverflowException:"Exception_WasThrown"`
> I can use the functionality of this property normally after override it on my project

I checked the source code and found that there was a line of code that would cause the program to loop, so I removed it
