### PR TITLE
Repair and Enhancement.

### DIFF
--- a/src/ReaLTaiizor/Controls/Button/PoisonButton.cs
+++ b/src/ReaLTaiizor/Controls/Button/PoisonButton.cs
@@ -141,6 +141,15 @@ namespace ReaLTaiizor.Controls
         [DefaultValue(false)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
         public bool Highlight { get; set; } = false;
+
+        private bool useCustomFont = false;
+        [DefaultValue(false)]
+        [Category(PoisonDefaults.PropertyCategory.Appearance)]
+        public bool UseCustomFont {
+            get => useCustomFont;
+            set { useCustomFont = value; Refresh(); }
+        }
+
         [DefaultValue(PoisonButtonSize.Small)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
         public PoisonButtonSize FontSize { get; set; } = PoisonButtonSize.Small;
@@ -151,6 +160,22 @@ namespace ReaLTaiizor.Controls
         private bool isHovered = false;
         private bool isPressed = false;
         private bool isFocused = false;
+
+        #endregion
+
+        #region Routing Fields
+        public override Font Font {
+            get {
+                if (useCustomFont)
+                    return base.Font;
+                else
+                    return PoisonFonts.Button(FontSize, FontWeight);
+            }
+            set {
+                base.Font = value;
+                Refresh();
+            }
+        }
 
         #endregion
 
@@ -283,7 +308,7 @@ namespace ReaLTaiizor.Controls
                 e.Graphics.DrawRectangle(p, borderRect);
             }
 
-            TextRenderer.DrawText(e.Graphics, Text, PoisonFonts.Button(FontSize, FontWeight), ClientRectangle, foreColor, PoisonPaint.GetTextFormatFlags(TextAlign));
+            TextRenderer.DrawText(e.Graphics, Text, Font, ClientRectangle, foreColor, PoisonPaint.GetTextFormatFlags(TextAlign));
 
             OnCustomPaintForeground(new PoisonPaintEventArgs(Color.Empty, foreColor, e.Graphics));
 

--- a/src/ReaLTaiizor/Controls/CheckBox/PoisonCheckBox.cs
+++ b/src/ReaLTaiizor/Controls/CheckBox/PoisonCheckBox.cs
@@ -137,6 +137,15 @@ namespace ReaLTaiizor.Controls
         [DefaultValue(false)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
         public bool DisplayFocus { get; set; } = false;
+
+        private bool useCustomFont = false;
+        [DefaultValue(false)]
+        [Category(PoisonDefaults.PropertyCategory.Appearance)]
+        public bool UseCustomFont {
+            get => useCustomFont;
+            set { useCustomFont = value; Refresh(); }
+        }
+
         [DefaultValue(PoisonCheckBoxSize.Small)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
         public PoisonCheckBoxSize FontSize { get; set; } = PoisonCheckBoxSize.Small;
@@ -144,16 +153,25 @@ namespace ReaLTaiizor.Controls
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
         public PoisonCheckBoxWeight FontWeight { get; set; } = PoisonCheckBoxWeight.Regular;
 
-        [Browsable(false)]
-        public override Font Font
-        {
-            get => base.Font;
-            set => base.Font = value;
-        }
-
         private bool isHovered = false;
         private bool isPressed = false;
         private bool isFocused = false;
+
+        #endregion
+
+        #region Routing Fields
+        public override Font Font {
+            get {
+                if (useCustomFont)
+                    return base.Font;
+                else
+                    return PoisonFonts.CheckBox(FontSize, FontWeight);
+            }
+            set {
+                base.Font = value;
+                Refresh();
+            }
+        }
 
         #endregion
 
@@ -326,7 +344,7 @@ namespace ReaLTaiizor.Controls
             }
 
 
-            TextRenderer.DrawText(e.Graphics, Text, PoisonFonts.CheckBox(FontSize, FontWeight), textRect, foreColor, PoisonPaint.GetTextFormatFlags(TextAlign, !AutoSize));
+            TextRenderer.DrawText(e.Graphics, Text, Font, textRect, foreColor, PoisonPaint.GetTextFormatFlags(TextAlign, !AutoSize));
 
             OnCustomPaintForeground(new PoisonPaintEventArgs(Color.Empty, foreColor, e.Graphics));
 
@@ -471,7 +489,7 @@ namespace ReaLTaiizor.Controls
             using (Graphics g = CreateGraphics())
             {
                 proposedSize = new(int.MaxValue, int.MaxValue);
-                preferredSize = TextRenderer.MeasureText(g, Text, PoisonFonts.CheckBox(FontSize, FontWeight), proposedSize, PoisonPaint.GetTextFormatFlags(TextAlign));
+                preferredSize = TextRenderer.MeasureText(g, Text, Font, proposedSize, PoisonPaint.GetTextFormatFlags(TextAlign));
                 preferredSize.Width += 16;
 
                 if (CheckAlign is ContentAlignment.TopCenter or ContentAlignment.BottomCenter)

--- a/src/ReaLTaiizor/Controls/ComboBox/PoisonComboBox.cs
+++ b/src/ReaLTaiizor/Controls/ComboBox/PoisonComboBox.cs
@@ -190,6 +190,15 @@ namespace ReaLTaiizor.Controls
             }
         }
 
+        private bool useCustomFont = false;
+        [DefaultValue(false)]
+        [Category(PoisonDefaults.PropertyCategory.Appearance)]
+        public bool UseCustomFont {
+            get => useCustomFont;
+            set { useCustomFont = value; Refresh(); }
+        }
+
+
         [DefaultValue(PoisonComboBoxSize.Medium)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
         public PoisonComboBoxSize FontSize { get; set; } = PoisonComboBoxSize.Medium;
@@ -219,13 +228,6 @@ namespace ReaLTaiizor.Controls
         }
 
         private bool drawPrompt = false;
-
-        [Browsable(false)]
-        public override Font Font
-        {
-            get => base.Font;
-            set => base.Font = value;
-        }
 
         private AutoCompleteMode autoCompleteMode = AutoCompleteMode.None;
         public new AutoCompleteMode AutoCompleteMode
@@ -273,6 +275,23 @@ namespace ReaLTaiizor.Controls
 
         #endregion
 
+        #region Routing Fields
+        public override Font Font {
+            get {
+                if (useCustomFont)
+                    return base.Font;
+                else
+                    return PoisonFonts.ComboBox(FontSize, FontWeight);
+            }
+            set {
+                base.Font = value;
+                Refresh();
+            }
+        }
+
+        #endregion
+
+
         #region Constructor
 
         public PoisonComboBox()
@@ -296,7 +315,7 @@ namespace ReaLTaiizor.Controls
             textBox.Location = new System.Drawing.Point(0, 0);
             textBox.FontSize = (PoisonTextBoxSize)FontSize;
             textBox.FontWeight = (PoisonTextBoxWeight)FontWeight;
-            textBox.WaterMarkFont = PoisonFonts.ComboBox(FontSize, FontWeight);
+            textBox.WaterMarkFont = Font;
             textBox.Size = Size;
             textBox.TabIndex = 0;
             textBox.Margin = new Padding(0);
@@ -443,11 +462,11 @@ namespace ReaLTaiizor.Controls
 
                 if (Enabled)
                 {
-                    TextRenderer.DrawText(e.Graphics, Text, PoisonFonts.ComboBox(FontSize, FontWeight), textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+                    TextRenderer.DrawText(e.Graphics, Text, Font, textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
                 }
                 else
                 {
-                    ControlPaint.DrawStringDisabled(e.Graphics, Text, PoisonFonts.ComboBox(FontSize, FontWeight), PoisonPaint.ForeColor.ComboBox.Disabled(Theme), textRect, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+                    ControlPaint.DrawStringDisabled(e.Graphics, Text, Font, PoisonPaint.ForeColor.ComboBox.Disabled(Theme), textRect, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
                 }
 
                 OnCustomPaintForeground(new PoisonPaintEventArgs(Color.Empty, foreColor, e.Graphics));
@@ -493,12 +512,12 @@ namespace ReaLTaiizor.Controls
                 if (DropDownStyle != ComboBoxStyle.DropDown)
                 {
                     Rectangle textRect = new(0, e.Bounds.Top, e.Bounds.Width, e.Bounds.Height);
-                    TextRenderer.DrawText(e.Graphics, GetItemText(Items[e.Index]), PoisonFonts.ComboBox(FontSize, FontWeight), textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+                    TextRenderer.DrawText(e.Graphics, GetItemText(Items[e.Index]), Font, textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
                 }
                 else
                 {
                     Rectangle textRect = new(0, e.Bounds.Top, textBox.Width, e.Bounds.Height);
-                    TextRenderer.DrawText(e.Graphics, GetItemText(Items[e.Index]), PoisonFonts.ComboBox(FontSize, FontWeight), textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+                    TextRenderer.DrawText(e.Graphics, GetItemText(Items[e.Index]), Font, textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
                 }
             }
             else
@@ -524,7 +543,7 @@ namespace ReaLTaiizor.Controls
             }
 
             Rectangle textRect = new(2, 2, Width - 20, Height - 4);
-            TextRenderer.DrawText(g, promptText, PoisonFonts.ComboBox(FontSize, FontWeight), textRect, SystemColors.GrayText, backColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
+            TextRenderer.DrawText(g, promptText, Font, textRect, SystemColors.GrayText, backColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
         }
 
         #endregion
@@ -662,7 +681,7 @@ namespace ReaLTaiizor.Controls
             {
                 string measureText = Text.Length > 0 ? Text : "MeasureText";
                 proposedSize = new(int.MaxValue, int.MaxValue);
-                preferredSize = TextRenderer.MeasureText(g, measureText, PoisonFonts.ComboBox(FontSize, FontWeight), proposedSize, TextFormatFlags.Left | TextFormatFlags.LeftAndRightPadding | TextFormatFlags.VerticalCenter);
+                preferredSize = TextRenderer.MeasureText(g, measureText, Font, proposedSize, TextFormatFlags.Left | TextFormatFlags.LeftAndRightPadding | TextFormatFlags.VerticalCenter);
                 preferredSize.Height += 4;
             }
 

--- a/src/ReaLTaiizor/Controls/DateTime/PoisonDateTime.cs
+++ b/src/ReaLTaiizor/Controls/DateTime/PoisonDateTime.cs
@@ -137,6 +137,15 @@ namespace ReaLTaiizor.Controls
         public bool DisplayFocus { get; set; } = false;
         [DefaultValue(PoisonDateTimeSize.Medium)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
+
+        private bool useCustomFont = false;
+        [DefaultValue(false)]
+        [Category(PoisonDefaults.PropertyCategory.Appearance)]
+        public bool UseCustomFont {
+            get => useCustomFont;
+            set { useCustomFont = value; Refresh(); }
+        }
+
         public PoisonDateTimeSize FontSize { get; set; } = PoisonDateTimeSize.Medium;
         [DefaultValue(PoisonDateTimeWeight.Regular)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
@@ -150,16 +159,25 @@ namespace ReaLTaiizor.Controls
             set => base.ShowUpDown = false;
         }
 
-        [Browsable(false)]
-        public override Font Font
-        {
-            get => base.Font;
-            set => base.Font = value;
-        }
-
         private bool isHovered = false;
         private bool isPressed = false;
         private bool isFocused = false;
+
+        #endregion
+
+        #region Routing Fields
+        public override Font Font {
+            get {
+                if (useCustomFont)
+                    return base.Font;
+                else
+                    return PoisonFonts.DateTime(FontSize, FontWeight);
+            }
+            set {
+                base.Font = value;
+                Refresh();
+            }
+        }
 
         #endregion
 
@@ -291,7 +309,7 @@ namespace ReaLTaiizor.Controls
 
             Rectangle textRect = new(2 + _check, 2, Width - 20, Height - 4);
 
-            TextRenderer.DrawText(e.Graphics, Text, PoisonFonts.DateTime(FontSize, FontWeight), textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+            TextRenderer.DrawText(e.Graphics, Text, Font, textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
 
             OnCustomPaintForeground(new PoisonPaintEventArgs(Color.Empty, foreColor, e.Graphics));
 
@@ -430,7 +448,7 @@ namespace ReaLTaiizor.Controls
             {
                 string measureText = Text.Length > 0 ? Text : "MeasureText";
                 proposedSize = new(int.MaxValue, int.MaxValue);
-                preferredSize = TextRenderer.MeasureText(g, measureText, PoisonFonts.DateTime(FontSize, FontWeight), proposedSize, TextFormatFlags.Left | TextFormatFlags.LeftAndRightPadding | TextFormatFlags.VerticalCenter);
+                preferredSize = TextRenderer.MeasureText(g, measureText, Font, proposedSize, TextFormatFlags.Left | TextFormatFlags.LeftAndRightPadding | TextFormatFlags.VerticalCenter);
                 preferredSize.Height += 10;
             }
 

--- a/src/ReaLTaiizor/Controls/Label/PoisonLabel.cs
+++ b/src/ReaLTaiizor/Controls/Label/PoisonLabel.cs
@@ -137,6 +137,14 @@ namespace ReaLTaiizor.Controls
 
         private readonly DoubleBufferedTextBox baseTextBox;
 
+        private bool useCustomFont=false;
+        [DefaultValue(false)]
+        [Category(PoisonDefaults.PropertyCategory.Appearance)]
+        public bool UseCustomFont {
+            get => useCustomFont;
+            set { useCustomFont = value; Refresh(); }
+        }
+
         private PoisonLabelSize poisonLabelSize = PoisonLabelSize.Medium;
         [DefaultValue(PoisonLabelSize.Medium)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
@@ -166,6 +174,22 @@ namespace ReaLTaiizor.Controls
         {
             get => wrapToLine;
             set { wrapToLine = value; Refresh(); }
+        }
+
+        #endregion
+
+        #region Routing Fields
+        public override Font Font {
+            get {
+                if (useCustomFont) 
+                    return base.Font;
+                else 
+                    return PoisonFonts.Label(poisonLabelSize, poisonLabelWeight);
+            }
+            set {
+                base.Font = value;
+                Refresh();
+            }
         }
 
         #endregion
@@ -312,13 +336,13 @@ namespace ReaLTaiizor.Controls
 
                 if (!baseTextBox.Visible)
                 {
-                    TextRenderer.DrawText(e.Graphics, Text, PoisonFonts.Label(poisonLabelSize, poisonLabelWeight), ClientRectangle, foreColor, PoisonPaint.GetTextFormatFlags(TextAlign));
+                    TextRenderer.DrawText(e.Graphics, Text, Font, ClientRectangle, foreColor, PoisonPaint.GetTextFormatFlags(TextAlign));
                 }
             }
             else
             {
                 DestroyBaseTextbox();
-                TextRenderer.DrawText(e.Graphics, Text, PoisonFonts.Label(poisonLabelSize, poisonLabelWeight), ClientRectangle, foreColor, PoisonPaint.GetTextFormatFlags(TextAlign, wrapToLine));
+                TextRenderer.DrawText(e.Graphics, Text, Font, ClientRectangle, foreColor, PoisonPaint.GetTextFormatFlags(TextAlign, wrapToLine));
                 OnCustomPaintForeground(new PoisonPaintEventArgs(Color.Empty, foreColor, e.Graphics));
             }
         }
@@ -345,7 +369,7 @@ namespace ReaLTaiizor.Controls
             using (Graphics g = CreateGraphics())
             {
                 proposedSize = new(int.MaxValue, int.MaxValue);
-                preferredSize = TextRenderer.MeasureText(g, Text, PoisonFonts.Label(poisonLabelSize, poisonLabelWeight), proposedSize, PoisonPaint.GetTextFormatFlags(TextAlign));
+                preferredSize = TextRenderer.MeasureText(g, Text, Font, proposedSize, PoisonPaint.GetTextFormatFlags(TextAlign));
             }
 
             return preferredSize;
@@ -418,7 +442,7 @@ namespace ReaLTaiizor.Controls
             baseTextBox.BackColor = Color.Transparent;
             baseTextBox.Visible = true;
             baseTextBox.BorderStyle = BorderStyle.None;
-            baseTextBox.Font = PoisonFonts.Label(poisonLabelSize, poisonLabelWeight);
+            baseTextBox.Font = Font;
             baseTextBox.Location = new(1, 0);
             baseTextBox.Text = Text;
             baseTextBox.ReadOnly = true;
@@ -544,7 +568,7 @@ namespace ReaLTaiizor.Controls
                 }
             }
 
-            baseTextBox.Font = PoisonFonts.Label(poisonLabelSize, poisonLabelWeight);
+            baseTextBox.Font = Font;
             baseTextBox.Text = Text;
             baseTextBox.BorderStyle = BorderStyle.None;
 

--- a/src/ReaLTaiizor/Controls/TextBox/PoisonTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/PoisonTextBox.cs
@@ -136,6 +136,14 @@ namespace ReaLTaiizor.Controls
 
         private PromptedTextBox baseTextBox;
 
+        private bool useCustomFont = false;
+        [DefaultValue(false)]
+        [Category(PoisonDefaults.PropertyCategory.Appearance)]
+        public bool UseCustomFont {
+            get => useCustomFont;
+            set { useCustomFont = value; Refresh(); }
+        }
+
         private PoisonTextBoxSize poisonTextBoxSize = PoisonTextBoxSize.Small;
         [DefaultValue(PoisonTextBoxSize.Small)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
@@ -317,6 +325,19 @@ namespace ReaLTaiizor.Controls
         #endregion
 
         #region Routing Fields
+
+        public override Font Font {
+            get {
+                if (useCustomFont)
+                    return base.Font;
+                else
+                    return PoisonFonts.TextBox(poisonTextBoxSize, poisonTextBoxWeight);
+            }
+            set {
+                base.Font = value;
+                Refresh();
+            }
+        }
 
 #if !NETCOREAPP3_1 && !NET6_0 && !NET7_0 && !NET8_0 && !NET9_0
         public override ContextMenu ContextMenu
@@ -740,7 +761,7 @@ namespace ReaLTaiizor.Controls
             baseTextBox = new PromptedTextBox
             {
                 BorderStyle = BorderStyle.None,
-                Font = PoisonFonts.TextBox(poisonTextBoxSize, poisonTextBoxWeight),
+                Font = this.Font,
                 Location = new(3, 3),
                 Size = new(Width - 6, Height - 6)
             };
@@ -910,7 +931,7 @@ namespace ReaLTaiizor.Controls
                 return;
             }
 
-            baseTextBox.Font = PoisonFonts.TextBox(poisonTextBoxSize, poisonTextBoxWeight);
+            baseTextBox.Font = Font;
 
             if (displayIcon)
             {

--- a/src/ReaLTaiizor/Forms/Form/PoisonForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/PoisonForm.cs
@@ -765,39 +765,30 @@ namespace ReaLTaiizor.Forms
 
             Dictionary<int, WindowButtons> priorityOrder = new(3) { { 0, WindowButtons.Close }, { 1, WindowButtons.Maximize }, { 2, WindowButtons.Minimize } };
 
-            Point firstButtonLocation = new(ClientRectangle.Width - borderWidth - 25, borderWidth);
-            int lastDrawedButtonPosition = firstButtonLocation.X - 25;
+            int firstButtonPosition = ClientRectangle.Width - borderWidth - 25;
+            int lastDrawedButtonPosition = firstButtonPosition - 25;
 
-            PoisonFormButton firstButton = null;
-
-            if (windowButtonList.Count == 1)
-            {
-                foreach (KeyValuePair<WindowButtons, PoisonFormButton> button in windowButtonList)
-                {
-                    button.Value.Location = firstButtonLocation;
-                }
+            bool firstButtonSet = false;
+            void SetButtonPosition(WindowButtons button,int x) {
+                windowButtonList[button].Anchor = AnchorStyles.None;//需要先解除锚点，否则在缩放设置不同的系统上会出现位置设置失败的bug
+                windowButtonList[button].Location = new(x, borderWidth);
+                windowButtonList[button].Anchor = AnchorStyles.Top | AnchorStyles.Right;//设置完位置后重新设置锚点
             }
-            else
-            {
-                foreach (KeyValuePair<int, WindowButtons> button in priorityOrder)
-                {
-                    bool buttonExists = windowButtonList.ContainsKey(button.Value);
+            foreach (KeyValuePair<int, WindowButtons> button in priorityOrder) {
+                bool buttonExists = windowButtonList.ContainsKey(button.Value);
 
-                    if (firstButton == null && buttonExists)
-                    {
-                        firstButton = windowButtonList[button.Value];
-                        firstButton.Location = firstButtonLocation;
-                        continue;
-                    }
-
-                    if (firstButton == null || !buttonExists)
-                    {
-                        continue;
-                    }
-
-                    windowButtonList[button.Value].Location = new(lastDrawedButtonPosition, borderWidth);
-                    lastDrawedButtonPosition -= 25;
+                if (firstButtonSet == false && buttonExists) {
+                    SetButtonPosition(button.Value, firstButtonPosition);
+                    firstButtonSet = true;
+                    continue;
                 }
+
+                if (firstButtonSet == false || !buttonExists) {
+                    continue;
+                }
+
+                SetButtonPosition(button.Value, lastDrawedButtonPosition);
+                lastDrawedButtonPosition -= 25;
             }
 
             Refresh();
@@ -987,7 +978,7 @@ namespace ReaLTaiizor.Forms
                 }
 
                 e.Graphics.Clear(backColor);
-                Font buttonFont = new("Webdings", 9.25f);
+                Font buttonFont = new("Webdings", 9.75f, GraphicsUnit.Pixel);
                 TextRenderer.DrawText(e.Graphics, Text, buttonFont, ClientRectangle, foreColor, backColor, TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
             }
 


### PR DESCRIPTION
- Fixed some visual issues for `PoisonForm` 2672cea
  - Different zoom settings in the system can result in window buttons not displaying properly and being misplaced.
    > Before repair:
      ![](https://github.com/user-attachments/assets/2c12c044-62f2-4b10-b1f4-86168a128046)
      After repair:
      ![](https://github.com/user-attachments/assets/bcfca996-47f7-4003-964d-f274aa8798dd)
- Added new attribute `UseCustomFont` for some `Poison` series controls b11efed
  > I found that they cannot customize the font size and style, so I added this attribute. When this property is true, the `Font` property of the control will be used to control the font style.