### PR TITLE
Fixed a problem about Custom Style Color in Poison style.

### DIFF
--- a/src/ReaLTaiizor/Controls/Progress/PoisonProgressSpinner.cs
+++ b/src/ReaLTaiizor/Controls/Progress/PoisonProgressSpinner.cs
@@ -135,6 +135,7 @@ namespace ReaLTaiizor.Controls
         private readonly Timer timer;
         private int progress;
         private float angle = 270;
+        private int lineWidthRatio = 5;
 
         [DefaultValue(true)]
         [Category(PoisonDefaults.PropertyCategory.Behaviour)]
@@ -143,6 +144,25 @@ namespace ReaLTaiizor.Controls
             get => timer.Enabled;
             set => timer.Enabled = value;
         }
+
+        
+
+        [DefaultValue(5)]
+        public int LineWidthRatio
+        {
+            get => lineWidthRatio;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException("Progress value must be a number more than zero.", (Exception)null);
+                }
+
+                progress = value;
+                Refresh();
+            }
+        }
+
 
         [DefaultValue(0)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
@@ -366,7 +386,7 @@ namespace ReaLTaiizor.Controls
                 }
             }
 
-            using (Pen forePen = new(foreColor, (float)Width / 5))
+            using (Pen forePen = new(foreColor, (float)Width / lineWidthRatio))
             {
                 int padding = (int)Math.Ceiling((float)Width / 10);
 

--- a/src/ReaLTaiizor/Controls/Progress/PoisonProgressSpinner.cs
+++ b/src/ReaLTaiizor/Controls/Progress/PoisonProgressSpinner.cs
@@ -135,7 +135,6 @@ namespace ReaLTaiizor.Controls
         private readonly Timer timer;
         private int progress;
         private float angle = 270;
-        private int lineWidthRatio = 5;
 
         [DefaultValue(true)]
         [Category(PoisonDefaults.PropertyCategory.Behaviour)]
@@ -144,25 +143,6 @@ namespace ReaLTaiizor.Controls
             get => timer.Enabled;
             set => timer.Enabled = value;
         }
-
-        
-
-        [DefaultValue(5)]
-        public int LineWidthRatio
-        {
-            get => lineWidthRatio;
-            set
-            {
-                if (value < 0)
-                {
-                    throw new ArgumentOutOfRangeException("Progress value must be a number more than zero.", (Exception)null);
-                }
-
-                progress = value;
-                Refresh();
-            }
-        }
-
 
         [DefaultValue(0)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
@@ -386,7 +366,7 @@ namespace ReaLTaiizor.Controls
                 }
             }
 
-            using (Pen forePen = new(foreColor, (float)Width / lineWidthRatio))
+            using (Pen forePen = new(foreColor, (float)Width / 5))
             {
                 int padding = (int)Math.Ceiling((float)Width / 10);
 

--- a/src/ReaLTaiizor/Controls/Progress/PoisonProgressSpinner.cs
+++ b/src/ReaLTaiizor/Controls/Progress/PoisonProgressSpinner.cs
@@ -135,6 +135,7 @@ namespace ReaLTaiizor.Controls
         private readonly Timer timer;
         private int progress;
         private float angle = 270;
+        private int lineWidthRatio;
 
         [DefaultValue(true)]
         [Category(PoisonDefaults.PropertyCategory.Behaviour)]
@@ -143,6 +144,25 @@ namespace ReaLTaiizor.Controls
             get => timer.Enabled;
             set => timer.Enabled = value;
         }
+
+
+
+        [DefaultValue(5)]
+        public int LineWidthRatio
+        {
+            get => lineWidthRatio;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException("Progress value must be a number more than zero.", (Exception)null);
+                }
+
+                lineWidthRatio = value;
+                Refresh();
+            }
+        }
+
 
         [DefaultValue(0)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]
@@ -366,7 +386,7 @@ namespace ReaLTaiizor.Controls
                 }
             }
 
-            using (Pen forePen = new(foreColor, (float)Width / 5))
+            using (Pen forePen = new(foreColor, (float)Width / lineWidthRatio))
             {
                 int padding = (int)Math.Ceiling((float)Width / 10);
 

--- a/src/ReaLTaiizor/Controls/Progress/PoisonProgressSpinner.cs
+++ b/src/ReaLTaiizor/Controls/Progress/PoisonProgressSpinner.cs
@@ -145,8 +145,6 @@ namespace ReaLTaiizor.Controls
             set => timer.Enabled = value;
         }
 
-
-
         [DefaultValue(5)]
         public int LineWidthRatio
         {
@@ -162,7 +160,6 @@ namespace ReaLTaiizor.Controls
                 Refresh();
             }
         }
-
 
         [DefaultValue(0)]
         [Category(PoisonDefaults.PropertyCategory.Appearance)]

--- a/src/ReaLTaiizor/Drawing/Poison/PoisonPaint.cs
+++ b/src/ReaLTaiizor/Drawing/Poison/PoisonPaint.cs
@@ -854,6 +854,7 @@ namespace ReaLTaiizor.Drawing.Poison
                 ColorStyle.Purple => PoisonColors.Purple,
                 ColorStyle.Red => PoisonColors.Red,
                 ColorStyle.Yellow => PoisonColors.Yellow,
+                ColorStyle.Custom => PoisonColors.Custom,
                 _ => PoisonColors.Blue,
             };
         }
@@ -876,6 +877,7 @@ namespace ReaLTaiizor.Drawing.Poison
                 ColorStyle.Purple => PoisonBrushes.Purple,
                 ColorStyle.Red => PoisonBrushes.Red,
                 ColorStyle.Yellow => PoisonBrushes.Yellow,
+                ColorStyle.Custom => PoisonBrushes.Custom,
                 _ => PoisonBrushes.Blue,
             };
         }
@@ -898,6 +900,7 @@ namespace ReaLTaiizor.Drawing.Poison
                 ColorStyle.Purple => PoisonPens.Purple,
                 ColorStyle.Red => PoisonPens.Red,
                 ColorStyle.Yellow => PoisonPens.Yellow,
+                ColorStyle.Custom => PoisonPens.Custom,
                 _ => PoisonPens.Blue,
             };
         }

--- a/src/ReaLTaiizor/Extension/Poison/PoisonPens.cs
+++ b/src/ReaLTaiizor/Extension/Poison/PoisonPens.cs
@@ -53,6 +53,8 @@ namespace ReaLTaiizor.Extension.Poison
         public static Pen Red => GetSavePen("Red", PoisonColors.Red);
 
         public static Pen Yellow => GetSavePen("Yellow", PoisonColors.Yellow);
+
+        public static Pen Custom => GetSavePen("Custom", PoisonColors.Custom);
     }
 
     #endregion


### PR DESCRIPTION
Hi there!

First of all, thank you for this amazing library. While using the Poison components, I noticed that UseCustomForeColor and Poison.ColorStyle.Custom were not functioning as expected.

After a deep dive into the source code, I found that while the Custom style exists in the enum, the corresponding logic in the drawing utilities (specifically within PoisonPaint.cs and PoisonPens.cs) seemed to be missing. This caused the rendering engine to default to Blue whenever ColorStyle.Custom was selected.

<img width="1426" height="959" alt="image" src="https://github.com/user-attachments/assets/f3926f41-63aa-4c16-bcfa-58fbac43a492" />


## Changes
In this PR, I have added the missing mappings for the Custom style:

PoisonPaint.cs: Added ColorStyle.Custom support to GetStyleColor, GetStyleBrush, and GetStylePen.

PoisonPens.cs: Added the static Custom pen property.

With these changes, developers can now successfully apply their own colors by setting PoisonColors.Custom and switching the style to Custom.

## Verification
I have tested these changes locally, and the controls now correctly pick up the user-defined custom colors without defaulting back to the standard theme colors.

**However, without a complete overview of all your code, there's still a possibility that you have defined another intended usage for Poison.ColorStyle.Custom. If so, please let me know the correct usage and feel free to close this PR. Thanks!** 

Looking forward to your feedback!

# Commit Note:
Both UseCustomForeColor and Poison.ColorStyle.Custom did not work. After browsing the code, I found that Pen Custom and related codes were likely forgotten. I have put it back in this commit, and now you can apply custom color by setting PoisonColors.Custom.