### PR TITLE
(Poison UI) Fixed one property which does not work and added some modern functions.

### DIFF
--- a/src/ReaLTaiizor/Controls/Progress/PoisonProgressBar.cs
+++ b/src/ReaLTaiizor/Controls/Progress/PoisonProgressBar.cs
@@ -169,8 +169,70 @@ namespace ReaLTaiizor.Controls
 
         private double ProgressBarWidth => (double)Value / Maximum * ClientRectangle.Width;
 
-        private int ProgressBarMarqueeWidth => ClientRectangle.Width / 3;
+        /// <summary>
+        /// Set to 0 if you want to apply default width.
+        /// </summary>
+        [DefaultValue(0)]
+        [Category(PoisonDefaults.PropertyCategory.Appearance)]
+        public int ProgressBarMarqueeWidth
+        {
+            get => field == 0 ? ClientRectangle.Width / 3 : field;
+            set
+            {
+                if (value < 0) throw new ArgumentOutOfRangeException("ProgressBarMarqueeWidth must be a number more than zero.", (Exception)null);
+                field = value;
+            }
+        } = 0;
 
+        [DefaultValue(100)]
+        public int MarqueeFPS 
+        { 
+            get; 
+            set
+            {
+                if (value <= 0) throw new ArgumentOutOfRangeException("MarqueeFPS must be a number more than zero.", (Exception)null);
+                field = value;
+                if (marqueeTimer != null)
+                {
+                    marqueeTimer.Interval = 1000 / value;
+                }
+            }
+        } = 100;
+
+        /// <summary>
+        /// Same usage as Winforms originally included.
+        /// </summary>
+        [DefaultValue(100)]
+        public new int MarqueeAnimationSpeed 
+        { 
+            get; 
+            set
+            {
+                if (value <= 0) throw new ArgumentOutOfRangeException("MarqueeAnimationSpeed value must be a number more than zero.", (Exception)null);
+                field = value;
+            }
+        } = 100;
+
+        /// <summary>
+        /// If enabled, the marquee will change its speed like a material design ProgressBar like.
+        /// </summary>
+        [DefaultValue(false)]
+        [Category(PoisonDefaults.PropertyCategory.Appearance)]
+        public bool EnableMaterialMarqueeStyleSpeed { get; set; } = false;
+
+        /// <summary>
+        /// Indicates the ratio material design ProgressBar will speed up.
+        /// </summary>
+        [DefaultValue(3)]
+        public int MaterialStyleMarqueeSpeedRatio
+        {
+            get;
+            set
+            {
+                if (value <= 0) throw new ArgumentOutOfRangeException("MaterialStyleSpeedRatio value must be a number more than zero.", (Exception)null);
+                field = value;
+            }
+        } = 3;
         #endregion
 
         #region Constructor
@@ -302,7 +364,7 @@ namespace ReaLTaiizor.Controls
             graphics.FillRectangle(PoisonPaint.GetStyleBrush(Style), 0, 0, (int)ProgressBarWidth, ClientRectangle.Height);
         }
 
-        private int marqueeX = 0;
+        private float marqueeX = 0;
 
         private void DrawProgressMarquee(Graphics graphics)
         {
@@ -364,7 +426,7 @@ namespace ReaLTaiizor.Controls
 
             if (marqueeTimer == null)
             {
-                marqueeTimer = new Timer { Interval = 10 };
+                marqueeTimer = new Timer { Interval = 1000 / MarqueeFPS };
                 marqueeTimer.Tick += marqueeTimer_Tick;
             }
 
@@ -390,13 +452,28 @@ namespace ReaLTaiizor.Controls
             Invalidate();
         }
 
+        private bool materialEffectFlag = true;
         private void marqueeTimer_Tick(object sender, EventArgs e)
         {
-            marqueeX++;
+
+            marqueeX += (ClientRectangle.Width + ProgressBarMarqueeWidth) / (MarqueeAnimationSpeed * MarqueeFPS / 100F); 
+            // Here 100F is 1000/10, 'cause we need to support original anime users we keep a *10 ratio here.
 
             if (marqueeX > ClientRectangle.Width)
             {
                 marqueeX = -ProgressBarMarqueeWidth;
+                if (EnableMaterialMarqueeStyleSpeed)// Once fast, once slow
+                {
+                    if (materialEffectFlag)
+                    {
+                        MarqueeAnimationSpeed *= MaterialStyleMarqueeSpeedRatio;
+                    }
+                    else
+                    {
+                        MarqueeAnimationSpeed /= MaterialStyleMarqueeSpeedRatio;
+                    }
+                    materialEffectFlag = !materialEffectFlag;
+                }
             }
 
             Invalidate();


### PR DESCRIPTION
Hi there, it's me again.

I’ve been working on refining the PoisonProgressBar marquee animation logic. This PR aims to resolve the issue where marquee properties wouldn't update dynamically, while introducing new features to provide a smoother, more modern user experience.

## Things fixed in this PR

- **Fixed MarqueeAnimationSpeed Support**: The original WinForms MarqueeAnimationSpeed property was previously unimplemented or non-functional in the Poison style. I have added the necessary logic so users can now control the animation speed as expected.
- **Introduced MarqueeFPS**: To address the "choppy" feel of the native WinForms marquee (especially at low speeds), I added a MarqueeFPS property. This allows for high-refresh-rate animations, ensuring fluid movement regardless of the speed setting.

## New Features & Design Thoughts
- **Customizable Marquee Width**: Users can now define the width of the marquee highlight via the ProgressBarMarqueeWidth property.
- **A note on Material Design**: I noticed that the MaterialProgressBar animation isn't fully implemented yet. However, with the changes in this PR (speed/FPS control), we can already simulate a Material-like experience—such as the "staggered" (one fast, one slow) marquee cycle. I’ve also found that PoisonProgressSpinner can be adapted into a Material-style spinner using similar methods.

(Note: These Material-style behaviors can be built on top of these changes without further modifying the core code, so I have kept this PR focused on the essential logic. See the attached GIF for a preview of what's possible! Thanks again for your library! )

![screenshot](https://github.com/user-attachments/assets/52cfc499-3fba-4f61-8e55-cdbbd2a8ae7d)

A way to reproduce that material-design-alike spinner: 
<img width="1085" height="582" alt="image" src="https://github.com/user-attachments/assets/5206bd99-a8a1-44c8-a9bb-9c607583f4d4" />
(For a quick display, I disabled CheckForIllegalCrossThreadCalls and when it is for producing environment that should be replaced. )
(Sorry for my poor English..)

# Commit Notes
- Now original Winforms property MarqueeAnimationSpeed can function normally.
- Added FPS control function, to avoid low refresh rate like Winform original marquee style.
- Enabled users to customize the width of a marquee.
- Added a Material Design style animation control strategy.