### PR TITLE
Provide Windows DPI Scaling support for MaterialForm Controls and other improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,8 +239,3 @@ $RECYCLE.BIN/
 
 #React.JS
 .module-cache
-/HYrecvDevDemo/HYrecvDevDemo.csproj
-/HYrecvDevDemo/Form1.cs
-/HYrecvDevDemo/Form1.Designer.cs
-/HYrecvDevDemo/Form1.resx
-/HYrecvDevDemo/Program.cs

--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,8 @@ $RECYCLE.BIN/
 
 #React.JS
 .module-cache
+/HYrecvDevDemo/HYrecvDevDemo.csproj
+/HYrecvDevDemo/Form1.cs
+/HYrecvDevDemo/Form1.Designer.cs
+/HYrecvDevDemo/Form1.resx
+/HYrecvDevDemo/Program.cs

--- a/demo/ReaLTaiizor.UI/ReaLTaiizor.UI/Form17.Designer.cs
+++ b/demo/ReaLTaiizor.UI/ReaLTaiizor.UI/Form17.Designer.cs
@@ -2018,8 +2018,6 @@ namespace ReaLTaiizor.UI
             materialTextBox5.Cursor = Cursors.IBeam;
             materialTextBox5.Depth = 0;
             materialTextBox5.Enabled = false;
-            materialTextBox5.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
-            materialTextBox5.HideSelection = true;
             materialTextBox5.Hint = "This is Disabled";
             materialTextBox5.LeadingIcon = null;
             materialTextBox5.Location = new System.Drawing.Point(222, 170);
@@ -2039,8 +2037,8 @@ namespace ReaLTaiizor.UI
             materialTextBox5.TabStop = false;
             materialTextBox5.Text = "But with value";
             materialTextBox5.TextAlign = HorizontalAlignment.Left;
-            materialTextBox5.TrailingIcon = null;
-            materialTextBox5.UseSystemPasswordChar = false;
+            //materialTextBox5.TrailingIcon = null;
+            //materialTextBox5.UseSystemPasswordChar = false;
             // 
             // materialTextBox4
             // 
@@ -3361,63 +3359,64 @@ namespace ReaLTaiizor.UI
             // materialContextMenuStrip1
             // 
             materialContextMenuStrip1.BackColor = System.Drawing.Color.White;
-            materialContextMenuStrip1.Depth = 0;
-            materialContextMenuStrip1.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
-            materialContextMenuStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            // materialContextMenuStrip1.Depth = 0;
+            materialContextMenuStrip1.AutoSize = true;
+            // materialContextMenuStrip1.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            // materialContextMenuStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             materialContextMenuStrip1.Items.AddRange(new ToolStripItem[] { item1ToolStripMenuItem, disabledItemToolStripMenuItem, item2ToolStripMenuItem, toolStripSeparator1, item3ToolStripMenuItem });
-            materialContextMenuStrip1.Margin = new Padding(16, 8, 16, 8);
-            materialContextMenuStrip1.MouseState = Helper.MaterialDrawHelper.MaterialMouseState.HOVER;
+            // materialContextMenuStrip1.Margin = new Padding(16, 8, 16, 8);
+            // materialContextMenuStrip1.MouseState = Helper.MaterialDrawHelper.MaterialMouseState.HOVER;
             materialContextMenuStrip1.Name = "materialContextMenuStrip1";
-            materialContextMenuStrip1.Size = new System.Drawing.Size(170, 130);
+            // materialContextMenuStrip1.Size = new System.Drawing.Size(170, 130);
             // 
             // item1ToolStripMenuItem
             // 
-            item1ToolStripMenuItem.AutoSize = false;
+            item1ToolStripMenuItem.AutoSize = true;
             item1ToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { subItem1ToolStripMenuItem, subItem2ToolStripMenuItem });
             item1ToolStripMenuItem.Image = Properties.Resources.minus;
             item1ToolStripMenuItem.Name = "item1ToolStripMenuItem";
-            item1ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
+            // item1ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
             item1ToolStripMenuItem.Text = "Item 1";
             // 
             // subItem1ToolStripMenuItem
             // 
-            subItem1ToolStripMenuItem.AutoSize = false;
+            subItem1ToolStripMenuItem.AutoSize = true;
             subItem1ToolStripMenuItem.Name = "subItem1ToolStripMenuItem";
-            subItem1ToolStripMenuItem.Size = new System.Drawing.Size(152, 30);
+            // subItem1ToolStripMenuItem.Size = new System.Drawing.Size(152, 30);
             subItem1ToolStripMenuItem.Text = "SubItem 1";
             // 
             // subItem2ToolStripMenuItem
             // 
-            subItem2ToolStripMenuItem.AutoSize = false;
+            subItem2ToolStripMenuItem.AutoSize = true;
             subItem2ToolStripMenuItem.Name = "subItem2ToolStripMenuItem";
-            subItem2ToolStripMenuItem.Size = new System.Drawing.Size(152, 30);
+            // subItem2ToolStripMenuItem.Size = new System.Drawing.Size(152, 30);
             subItem2ToolStripMenuItem.Text = "SubItem 2";
             // 
             // disabledItemToolStripMenuItem
             // 
-            disabledItemToolStripMenuItem.AutoSize = false;
+            disabledItemToolStripMenuItem.AutoSize = true;
             disabledItemToolStripMenuItem.Enabled = false;
             disabledItemToolStripMenuItem.Name = "disabledItemToolStripMenuItem";
-            disabledItemToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
+            // disabledItemToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
             disabledItemToolStripMenuItem.Text = "Disabled item";
             // 
             // item2ToolStripMenuItem
             // 
-            item2ToolStripMenuItem.AutoSize = false;
+            item2ToolStripMenuItem.AutoSize = true;
             item2ToolStripMenuItem.Name = "item2ToolStripMenuItem";
-            item2ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
+            // item2ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
             item2ToolStripMenuItem.Text = "Item 2";
             // 
             // toolStripSeparator1
             // 
             toolStripSeparator1.Name = "toolStripSeparator1";
-            toolStripSeparator1.Size = new System.Drawing.Size(166, 6);
+            // toolStripSeparator1.Size = new System.Drawing.Size(166, 6);
             // 
             // item3ToolStripMenuItem
             // 
-            item3ToolStripMenuItem.AutoSize = false;
+            item3ToolStripMenuItem.AutoSize = true;
             item3ToolStripMenuItem.Name = "item3ToolStripMenuItem";
-            item3ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
+            // item3ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
             item3ToolStripMenuItem.Text = "Item 3";
             // 
             // Form17

--- a/src/ReaLTaiizor/Child/Material/MaterialBaseTextBox.cs
+++ b/src/ReaLTaiizor/Child/Material/MaterialBaseTextBox.cs
@@ -86,10 +86,8 @@ namespace ReaLTaiizor.Child.Material
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -102,10 +100,8 @@ namespace ReaLTaiizor.Child.Material
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
         protected override void WndProc(ref Message m)
         {
@@ -224,10 +220,8 @@ namespace ReaLTaiizor.Child.Material
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -240,10 +234,8 @@ namespace ReaLTaiizor.Child.Material
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         protected override void WndProc(ref Message m)

--- a/src/ReaLTaiizor/Child/Material/MaterialBaseTextBox.cs
+++ b/src/ReaLTaiizor/Child/Material/MaterialBaseTextBox.cs
@@ -73,8 +73,45 @@ namespace ReaLTaiizor.Child.Material
         private const uint WM_USER = 0x0400;
         private const uint EM_SETBKGNDCOLOR = WM_USER + 67;
         private const uint WM_KILLFOCUS = 0x0008;
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
         protected override void WndProc(ref Message m)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.WndProc(ref m);
 
 
@@ -93,7 +130,7 @@ namespace ReaLTaiizor.Child.Material
                 using MaterialNativeTextRenderer NativeText = new(Graphics.FromHwnd(m.HWnd));
                 NativeText.DrawTransparentText(
                 Hint,
-                SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor()),
+                SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor),
                 Enabled ?
                 MaterialColorHelper.RemoveAlpha(SkinManager.TextMediumEmphasisColor, BackColor) : // not focused
                 MaterialColorHelper.RemoveAlpha(SkinManager.TextDisabledOrHintColor, BackColor), // Disabled
@@ -114,20 +151,6 @@ namespace ReaLTaiizor.Child.Material
 
         }
 
-        private float GetDeviceScaleFactor()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)this.DeviceDpi / 96f;
-            return scalingFactor;
-        }
-
-        private float GetDeviceScaleFactorSqrt()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            return scalingFactor;
-        }
 
     }
 
@@ -188,8 +211,46 @@ namespace ReaLTaiizor.Child.Material
         private const uint WM_USER = 0x0400;
         private const uint EM_SETBKGNDCOLOR = WM_USER + 67;
         private const uint WM_KILLFOCUS = 0x0008;
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         protected override void WndProc(ref Message m)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.WndProc(ref m);
 
 
@@ -208,7 +269,7 @@ namespace ReaLTaiizor.Child.Material
                 using MaterialNativeTextRenderer NativeText = new(Graphics.FromHwnd(m.HWnd));
                 NativeText.DrawTransparentText(
                 Hint,
-                SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor()),
+                SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor),
                 Enabled ?
                 MaterialColorHelper.RemoveAlpha(SkinManager.TextMediumEmphasisColor, BackColor) : // not focused
                 MaterialColorHelper.RemoveAlpha(SkinManager.TextDisabledOrHintColor, BackColor), // Disabled
@@ -229,20 +290,6 @@ namespace ReaLTaiizor.Child.Material
 
         }
 
-        private float GetDeviceScaleFactor()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)this.DeviceDpi / 96f;
-            return scalingFactor;
-        }
-
-        private float GetDeviceScaleFactorSqrt()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            return scalingFactor;
-        }
 
     }
 

--- a/src/ReaLTaiizor/Child/Material/MaterialBaseTextBox.cs
+++ b/src/ReaLTaiizor/Child/Material/MaterialBaseTextBox.cs
@@ -93,7 +93,7 @@ namespace ReaLTaiizor.Child.Material
                 using MaterialNativeTextRenderer NativeText = new(Graphics.FromHwnd(m.HWnd));
                 NativeText.DrawTransparentText(
                 Hint,
-                SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1),
+                SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor()),
                 Enabled ?
                 MaterialColorHelper.RemoveAlpha(SkinManager.TextMediumEmphasisColor, BackColor) : // not focused
                 MaterialColorHelper.RemoveAlpha(SkinManager.TextDisabledOrHintColor, BackColor), // Disabled
@@ -112,6 +112,21 @@ namespace ReaLTaiizor.Child.Material
                 Invalidate();
             }
 
+        }
+
+        private float GetDeviceScaleFactor()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)this.DeviceDpi / 96f;
+            return scalingFactor;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
         }
 
     }
@@ -193,7 +208,7 @@ namespace ReaLTaiizor.Child.Material
                 using MaterialNativeTextRenderer NativeText = new(Graphics.FromHwnd(m.HWnd));
                 NativeText.DrawTransparentText(
                 Hint,
-                SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1),
+                SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor()),
                 Enabled ?
                 MaterialColorHelper.RemoveAlpha(SkinManager.TextMediumEmphasisColor, BackColor) : // not focused
                 MaterialColorHelper.RemoveAlpha(SkinManager.TextDisabledOrHintColor, BackColor), // Disabled
@@ -213,6 +228,22 @@ namespace ReaLTaiizor.Child.Material
             }
 
         }
+
+        private float GetDeviceScaleFactor()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)this.DeviceDpi / 96f;
+            return scalingFactor;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
+        }
+
     }
 
     #endregion

--- a/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
+++ b/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
@@ -500,8 +500,8 @@ namespace ReaLTaiizor.Controls
         /// <param name="pevent">The pevent<see cref="PaintEventArgs"/></param>
         protected override void OnPaint(PaintEventArgs pevent)
         {
-            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            // ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            // ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
             
             Graphics g = pevent.Graphics;
 
@@ -638,7 +638,7 @@ namespace ReaLTaiizor.Controls
             if (string.IsNullOrEmpty(Text))
             {
                 // Center Icon
-                iconRect.X += 2;
+                iconRect.X += (int)(2 * ScaleFactor);
             }
 
             if (Icon != null)

--- a/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
+++ b/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
@@ -5,12 +5,14 @@ using ReaLTaiizor.Helper;
 using ReaLTaiizor.Manager;
 using ReaLTaiizor.Util;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Drawing.Text;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static ReaLTaiizor.Helper.MaterialDrawHelper;
 using static ReaLTaiizor.Util.MaterialAnimations;
@@ -199,6 +201,23 @@ namespace ReaLTaiizor.Controls
             Invalidate();
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Release handle from CreateFont / LogFont
+                foreach (IntPtr handle in LFontToBeReleased)
+                {
+                    if (handle != IntPtr.Zero)
+                    {
+                        DeleteObject(handle);
+                    }
+                }
+                LFontToBeReleased.Clear();
+            }
+            base.Dispose(disposing);
+        }
+
         private bool _shadowDrawEventSubscribed = false;
 
         private void AddShadowPaintEvent(Control control, PaintEventHandler shadowPaintEvent)
@@ -228,6 +247,7 @@ namespace ReaLTaiizor.Controls
         private readonly AnimationManager _hoverAnimationManager = null;
         private readonly AnimationManager _focusAnimationManager = null;
         private readonly AnimationManager _animationManager = null;
+        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
 
         /// <summary>
         /// Defines the _textSize
@@ -359,12 +379,12 @@ namespace ReaLTaiizor.Controls
             MaterialDrawHelper.DrawSquareShadow(gp, rect);
         }
 
+
+        
         private float GetDeviceScaleFactor()
         {
             // 96 is Windows default scaling DPI（100% scale）
             float scalingFactor = (float)this.DeviceDpi / 96f;
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            // Buttons are not included in sqrt controls.
             return scalingFactor;
         }
 
@@ -740,6 +760,9 @@ namespace ReaLTaiizor.Controls
                 }
             };
         }
+
+        [DllImport("gdi32.dll", ExactSpelling = true)]
+        private static extern bool DeleteObject(IntPtr hObject);
     }
 
     #endregion

--- a/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
+++ b/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
@@ -120,11 +120,11 @@ namespace ReaLTaiizor.Controls
                 field = value;
                 if (field == MaterialButtonDensity.Dense)
                 {
-                    Size = new Size(Size.Width, HEIGHTDENSE);
+                    Size = new Size(Size.Width, (int)(HEIGHTDENSE * GetDeviceScaleFactor()));
                 }
                 else
                 {
-                    Size = new Size(Size.Width, HEIGHTDEFAULT);
+                    Size = new Size(Size.Width, (int)(HEIGHTDEFAULT * GetDeviceScaleFactor()));
                 }
 
                 Invalidate();
@@ -322,7 +322,7 @@ namespace ReaLTaiizor.Controls
 
                 if (!string.IsNullOrEmpty(value))
                 {
-                    _textSize = CreateGraphics().MeasureString(value.ToUpper(), SkinManager.GetFontByType(MaterialSkinManager.FontType.Button));
+                    _textSize = CreateGraphics().MeasureString(value.ToUpper(), SkinManager.GetFontByType(MaterialSkinManager.FontType.Button, GetDeviceScaleFactor()));
                 }
                 else
                 {
@@ -359,6 +359,23 @@ namespace ReaLTaiizor.Controls
             MaterialDrawHelper.DrawSquareShadow(gp, rect);
         }
 
+        private float GetDeviceScaleFactor()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)this.DeviceDpi / 96f;
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            // Buttons are not included in sqrt controls.
+            return scalingFactor;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
+        }
+
         private void preProcessIcons()
         {
             if (Icon == null)
@@ -367,28 +384,28 @@ namespace ReaLTaiizor.Controls
             }
 
             int newWidth, newHeight;
-            //Resize icon if greater than ICON_SIZE
-            if (Icon.Width > ICON_SIZE || Icon.Height > ICON_SIZE)
+            //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
+            if (Icon.Width > (int)(ICON_SIZE * GetDeviceScaleFactor()) || Icon.Height > (int)(ICON_SIZE * GetDeviceScaleFactor()))
             {
                 //calculate aspect ratio
                 float aspect = Icon.Width / (float)Icon.Height;
 
                 //calculate new dimensions based on aspect ratio
-                newWidth = (int)(ICON_SIZE * aspect);
+                newWidth = (int)((int)(ICON_SIZE * GetDeviceScaleFactor()) * aspect);
                 newHeight = (int)(newWidth / aspect);
 
                 //if one of the two dimensions exceed the box dimensions
-                if (newWidth > ICON_SIZE || newHeight > ICON_SIZE)
+                if (newWidth > (int)(ICON_SIZE * GetDeviceScaleFactor()) || newHeight > (int)(ICON_SIZE * GetDeviceScaleFactor()))
                 {
                     //depending on which of the two exceeds the box dimensions set it as the box dimension and calculate the other one based on the aspect ratio
                     if (newWidth > newHeight)
                     {
-                        newWidth = ICON_SIZE;
+                        newWidth = (int)(ICON_SIZE * GetDeviceScaleFactor());
                         newHeight = (int)(newWidth / aspect);
                     }
                     else
                     {
-                        newHeight = ICON_SIZE;
+                        newHeight = (int)(ICON_SIZE * GetDeviceScaleFactor());
                         newWidth = (int)(newHeight * aspect);
                     }
                 }
@@ -421,7 +438,7 @@ namespace ReaLTaiizor.Controls
             grayImageAttributes.SetColorMatrix(colorMatrixGray, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
 
             // Image Rect
-            Rectangle destRect = new(0, 0, ICON_SIZE, ICON_SIZE);
+            Rectangle destRect = new(0, 0, (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
 
             // Create a pre-processed copy of the image (GRAY)
             Bitmap bgray = new(destRect.Width, destRect.Height);
@@ -443,7 +460,7 @@ namespace ReaLTaiizor.Controls
             };
 
             // Translate the brushes to the correct positions
-            Rectangle iconRect = new(8, (Height / 2) - (ICON_SIZE / 2), ICON_SIZE, ICON_SIZE);
+            Rectangle iconRect = new(8, (Height / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
 
             textureBrushGray.TranslateTransform(iconRect.X + (iconRect.Width / 2) - (IconResized.Width / 2),
                                                 iconRect.Y + (iconRect.Height / 2) - (IconResized.Height / 2));
@@ -560,8 +577,8 @@ namespace ReaLTaiizor.Controls
             Rectangle textRect = ClientRectangle;
             if (Icon != null)
             {
-                textRect.Width -= 8 + ICON_SIZE + 4 + 8; // left padding + icon width + space between Icon and Text + right padding
-                textRect.X += 8 + ICON_SIZE + 4; // left padding + icon width + space between Icon and Text
+                textRect.Width -= 8 + (int)(ICON_SIZE * GetDeviceScaleFactor()) + 4 + 8; // left padding + icon width + space between Icon and Text + right padding
+                textRect.X += 8 + (int)(ICON_SIZE * GetDeviceScaleFactor()) + 4; // left padding + icon width + space between Icon and Text
             }
 
             Color textColor = Enabled ? (HighEmphasis ? (Type is MaterialButtonType.Text or MaterialButtonType.Outlined) ?
@@ -578,7 +595,7 @@ namespace ReaLTaiizor.Controls
                 NativeText.DrawMultilineTransparentText(
                     CharacterCasing == CharacterCasingEnum.Upper ? base.Text.ToUpper() : CharacterCasing == CharacterCasingEnum.Lower ? base.Text.ToLower() :
                         CharacterCasing == CharacterCasingEnum.Title ? CultureInfo.CurrentCulture.TextInfo.ToTitleCase(base.Text.ToLower()) : base.Text,
-                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Button),
+                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Button, GetDeviceScaleFactor()),
                     textColor,
                     textRect.Location,
                     textRect.Size,
@@ -586,7 +603,7 @@ namespace ReaLTaiizor.Controls
             }
 
             //Icon
-            Rectangle iconRect = new(8, (Height / 2) - (ICON_SIZE / 2), ICON_SIZE, ICON_SIZE);
+            Rectangle iconRect = new(8, (Height / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
 
             if (string.IsNullOrEmpty(Text))
             {
@@ -632,27 +649,27 @@ namespace ReaLTaiizor.Controls
             {
                 // 24 is for icon size
                 // 4 is for the space between icon & text
-                extra += ICON_SIZE + 4;
+                extra += (int)(ICON_SIZE * GetDeviceScaleFactor()) + 4;
             }
 
             if (AutoSize)
             {
                 s.Width = (int)Math.Ceiling(_textSize.Width);
                 s.Width += extra;
-                s.Height = HEIGHTDEFAULT;
+                s.Height = (int)(HEIGHTDEFAULT * GetDeviceScaleFactor());
             }
             else
             {
                 s.Width += extra;
-                s.Height = HEIGHTDEFAULT;
+                s.Height = (int)(HEIGHTDEFAULT * GetDeviceScaleFactor());
             }
-            if (Icon != null && Text.Length == 0 && s.Width < MINIMUMWIDTHICONONLY)
+            if (Icon != null && Text.Length == 0 && s.Width < (int)(MINIMUMWIDTHICONONLY * GetDeviceScaleFactor()))
             {
-                s.Width = MINIMUMWIDTHICONONLY;
+                s.Width = (int)(MINIMUMWIDTHICONONLY * GetDeviceScaleFactor());
             }
-            else if (s.Width < MINIMUMWIDTH)
+            else if (s.Width < (int)(MINIMUMWIDTH * GetDeviceScaleFactor()))
             {
-                s.Width = MINIMUMWIDTH;
+                s.Width = (int)(MINIMUMWIDTH * GetDeviceScaleFactor());
             }
 
             return s;

--- a/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
+++ b/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
@@ -41,10 +41,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -57,10 +55,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         // icons

--- a/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
+++ b/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
@@ -31,6 +31,40 @@ namespace ReaLTaiizor.Controls
         private const int HEIGHTDEFAULT = 36;
         private const int HEIGHTDENSE = 32;
 
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         // icons
         private TextureBrush iconsBrushes;
 
@@ -122,11 +156,11 @@ namespace ReaLTaiizor.Controls
                 field = value;
                 if (field == MaterialButtonDensity.Dense)
                 {
-                    Size = new Size(Size.Width, (int)(HEIGHTDENSE * GetDeviceScaleFactor()));
+                    Size = new Size(Size.Width, (int)(HEIGHTDENSE * ScaleFactor));
                 }
                 else
                 {
-                    Size = new Size(Size.Width, (int)(HEIGHTDEFAULT * GetDeviceScaleFactor()));
+                    Size = new Size(Size.Width, (int)(HEIGHTDEFAULT * ScaleFactor));
                 }
 
                 Invalidate();
@@ -331,7 +365,7 @@ namespace ReaLTaiizor.Controls
 
                 if (!string.IsNullOrEmpty(value))
                 {
-                    _textSize = CreateGraphics().MeasureString(value.ToUpper(), SkinManager.GetFontByType(MaterialSkinManager.FontType.Button, GetDeviceScaleFactor()));
+                    _textSize = CreateGraphics().MeasureString(value.ToUpper(), SkinManager.GetFontByType(MaterialSkinManager.FontType.Button, ScaleFactor));
                 }
                 else
                 {
@@ -368,23 +402,6 @@ namespace ReaLTaiizor.Controls
             MaterialDrawHelper.DrawSquareShadow(gp, rect);
         }
 
-
-        
-        private float GetDeviceScaleFactor()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)this.DeviceDpi / 96f;
-            return scalingFactor;
-        }
-
-        private float GetDeviceScaleFactorSqrt()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            return scalingFactor;
-        }
-
         private void preProcessIcons()
         {
             if (Icon == null)
@@ -393,28 +410,28 @@ namespace ReaLTaiizor.Controls
             }
 
             int newWidth, newHeight;
-            //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
-            if (Icon.Width > (int)(ICON_SIZE * GetDeviceScaleFactor()) || Icon.Height > (int)(ICON_SIZE * GetDeviceScaleFactor()))
+            //Resize icon if greater than (int)(ICON_SIZE * ScaleFactor)
+            if (Icon.Width > (int)(ICON_SIZE * ScaleFactor) || Icon.Height > (int)(ICON_SIZE * ScaleFactor))
             {
                 //calculate aspect ratio
                 float aspect = Icon.Width / (float)Icon.Height;
 
                 //calculate new dimensions based on aspect ratio
-                newWidth = (int)((int)(ICON_SIZE * GetDeviceScaleFactor()) * aspect);
+                newWidth = (int)((int)(ICON_SIZE * ScaleFactor) * aspect);
                 newHeight = (int)(newWidth / aspect);
 
                 //if one of the two dimensions exceed the box dimensions
-                if (newWidth > (int)(ICON_SIZE * GetDeviceScaleFactor()) || newHeight > (int)(ICON_SIZE * GetDeviceScaleFactor()))
+                if (newWidth > (int)(ICON_SIZE * ScaleFactor) || newHeight > (int)(ICON_SIZE * ScaleFactor))
                 {
                     //depending on which of the two exceeds the box dimensions set it as the box dimension and calculate the other one based on the aspect ratio
                     if (newWidth > newHeight)
                     {
-                        newWidth = (int)(ICON_SIZE * GetDeviceScaleFactor());
+                        newWidth = (int)(ICON_SIZE * ScaleFactor);
                         newHeight = (int)(newWidth / aspect);
                     }
                     else
                     {
-                        newHeight = (int)(ICON_SIZE * GetDeviceScaleFactor());
+                        newHeight = (int)(ICON_SIZE * ScaleFactor);
                         newWidth = (int)(newHeight * aspect);
                     }
                 }
@@ -447,7 +464,7 @@ namespace ReaLTaiizor.Controls
             grayImageAttributes.SetColorMatrix(colorMatrixGray, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
 
             // Image Rect
-            Rectangle destRect = new(0, 0, (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
+            Rectangle destRect = new(0, 0, (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
 
             // Create a pre-processed copy of the image (GRAY)
             Bitmap bgray = new(destRect.Width, destRect.Height);
@@ -469,7 +486,7 @@ namespace ReaLTaiizor.Controls
             };
 
             // Translate the brushes to the correct positions
-            Rectangle iconRect = new(8, (Height / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
+            Rectangle iconRect = new(8, (Height / 2) - ((int)(ICON_SIZE * ScaleFactor) / 2), (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
 
             textureBrushGray.TranslateTransform(iconRect.X + (iconRect.Width / 2) - (IconResized.Width / 2),
                                                 iconRect.Y + (iconRect.Height / 2) - (IconResized.Height / 2));
@@ -483,6 +500,9 @@ namespace ReaLTaiizor.Controls
         /// <param name="pevent">The pevent<see cref="PaintEventArgs"/></param>
         protected override void OnPaint(PaintEventArgs pevent)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            
             Graphics g = pevent.Graphics;
 
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
@@ -586,8 +606,8 @@ namespace ReaLTaiizor.Controls
             Rectangle textRect = ClientRectangle;
             if (Icon != null)
             {
-                textRect.Width -= 8 + (int)(ICON_SIZE * GetDeviceScaleFactor()) + 4 + 8; // left padding + icon width + space between Icon and Text + right padding
-                textRect.X += 8 + (int)(ICON_SIZE * GetDeviceScaleFactor()) + 4; // left padding + icon width + space between Icon and Text
+                textRect.Width -= 8 + (int)(ICON_SIZE * ScaleFactor) + 4 + 8; // left padding + icon width + space between Icon and Text + right padding
+                textRect.X += 8 + (int)(ICON_SIZE * ScaleFactor) + 4; // left padding + icon width + space between Icon and Text
             }
 
             Color textColor = Enabled ? (HighEmphasis ? (Type is MaterialButtonType.Text or MaterialButtonType.Outlined) ?
@@ -601,7 +621,7 @@ namespace ReaLTaiizor.Controls
 
             using (MaterialNativeTextRenderer NativeText = new(g))
             {
-                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Button, GetDeviceScaleFactor());
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Button, ScaleFactor);
                 NativeText.DrawMultilineTransparentText(
                     CharacterCasing == CharacterCasingEnum.Upper ? base.Text.ToUpper() : CharacterCasing == CharacterCasingEnum.Lower ? base.Text.ToLower() :
                         CharacterCasing == CharacterCasingEnum.Title ? CultureInfo.CurrentCulture.TextInfo.ToTitleCase(base.Text.ToLower()) : base.Text,
@@ -613,7 +633,7 @@ namespace ReaLTaiizor.Controls
             }
 
             //Icon
-            Rectangle iconRect = new(8, (Height / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
+            Rectangle iconRect = new(8, (Height / 2) - ((int)(ICON_SIZE * ScaleFactor) / 2), (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
 
             if (string.IsNullOrEmpty(Text))
             {
@@ -659,27 +679,27 @@ namespace ReaLTaiizor.Controls
             {
                 // 24 is for icon size
                 // 4 is for the space between icon & text
-                extra += (int)(ICON_SIZE * GetDeviceScaleFactor()) + 4;
+                extra += (int)(ICON_SIZE * ScaleFactor) + 4;
             }
 
             if (AutoSize)
             {
                 s.Width = (int)Math.Ceiling(_textSize.Width);
                 s.Width += extra;
-                s.Height = (int)(HEIGHTDEFAULT * GetDeviceScaleFactor());
+                s.Height = (int)(HEIGHTDEFAULT * ScaleFactor);
             }
             else
             {
                 s.Width += extra;
-                s.Height = (int)(HEIGHTDEFAULT * GetDeviceScaleFactor());
+                s.Height = (int)(HEIGHTDEFAULT * ScaleFactor);
             }
-            if (Icon != null && Text.Length == 0 && s.Width < (int)(MINIMUMWIDTHICONONLY * GetDeviceScaleFactor()))
+            if (Icon != null && Text.Length == 0 && s.Width < (int)(MINIMUMWIDTHICONONLY * ScaleFactor))
             {
-                s.Width = (int)(MINIMUMWIDTHICONONLY * GetDeviceScaleFactor());
+                s.Width = (int)(MINIMUMWIDTHICONONLY * ScaleFactor);
             }
-            else if (s.Width < (int)(MINIMUMWIDTH * GetDeviceScaleFactor()))
+            else if (s.Width < (int)(MINIMUMWIDTH * ScaleFactor))
             {
-                s.Width = (int)(MINIMUMWIDTH * GetDeviceScaleFactor());
+                s.Width = (int)(MINIMUMWIDTH * ScaleFactor);
             }
 
             return s;
@@ -751,8 +771,6 @@ namespace ReaLTaiizor.Controls
             };
         }
 
-        [DllImport("gdi32.dll", ExactSpelling = true)]
-        private static extern bool DeleteObject(IntPtr hObject);
     }
 
     #endregion

--- a/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
+++ b/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
@@ -5,14 +5,12 @@ using ReaLTaiizor.Helper;
 using ReaLTaiizor.Manager;
 using ReaLTaiizor.Util;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Drawing.Text;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static ReaLTaiizor.Helper.MaterialDrawHelper;
 using static ReaLTaiizor.Util.MaterialAnimations;
@@ -270,7 +268,7 @@ namespace ReaLTaiizor.Controls
         private readonly AnimationManager _hoverAnimationManager = null;
         private readonly AnimationManager _focusAnimationManager = null;
         private readonly AnimationManager _animationManager = null;
-        
+
 
         /// <summary>
         /// Defines the _textSize
@@ -502,7 +500,7 @@ namespace ReaLTaiizor.Controls
         {
             // ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
             // ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
-            
+
             Graphics g = pevent.Graphics;
 
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;

--- a/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
+++ b/src/ReaLTaiizor/Controls/Button/MaterialButton.cs
@@ -203,22 +203,11 @@ namespace ReaLTaiizor.Controls
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                // Release handle from CreateFont / LogFont
-                foreach (IntPtr handle in LFontToBeReleased)
-                {
-                    if (handle != IntPtr.Zero)
-                    {
-                        DeleteObject(handle);
-                    }
-                }
-                LFontToBeReleased.Clear();
-            }
             base.Dispose(disposing);
         }
 
         private bool _shadowDrawEventSubscribed = false;
+
 
         private void AddShadowPaintEvent(Control control, PaintEventHandler shadowPaintEvent)
         {
@@ -247,7 +236,7 @@ namespace ReaLTaiizor.Controls
         private readonly AnimationManager _hoverAnimationManager = null;
         private readonly AnimationManager _focusAnimationManager = null;
         private readonly AnimationManager _animationManager = null;
-        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
+        
 
         /// <summary>
         /// Defines the _textSize
@@ -612,10 +601,11 @@ namespace ReaLTaiizor.Controls
 
             using (MaterialNativeTextRenderer NativeText = new(g))
             {
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Button, GetDeviceScaleFactor());
                 NativeText.DrawMultilineTransparentText(
                     CharacterCasing == CharacterCasingEnum.Upper ? base.Text.ToUpper() : CharacterCasing == CharacterCasingEnum.Lower ? base.Text.ToLower() :
                         CharacterCasing == CharacterCasingEnum.Title ? CultureInfo.CurrentCulture.TextInfo.ToTitleCase(base.Text.ToLower()) : base.Text,
-                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Button, GetDeviceScaleFactor()),
+                    font,
                     textColor,
                     textRect.Location,
                     textRect.Size,

--- a/src/ReaLTaiizor/Controls/Button/MaterialFloatingActionButton.cs
+++ b/src/ReaLTaiizor/Controls/Button/MaterialFloatingActionButton.cs
@@ -302,8 +302,8 @@ namespace ReaLTaiizor.Controls
                 int target = Convert.ToInt32((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) * _showAnimationManager.GetProgress());
                 fabBounds.Width = target == 0 ? 1 : target;
                 fabBounds.Height = target == 0 ? 1 : target;
-                fabBounds.X = Convert.ToInt32(((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2) - ((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2 * _showAnimationManager.GetProgress()));
-                fabBounds.Y = Convert.ToInt32(((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2) - ((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2 * _showAnimationManager.GetProgress()));
+                fabBounds.X = Convert.ToInt32(((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2f) - ((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2f * _showAnimationManager.GetProgress()));
+                fabBounds.Y = Convert.ToInt32(((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2f) - ((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2f * _showAnimationManager.GetProgress()));
             }
 
             // Clip to a round shape with a 1px padding

--- a/src/ReaLTaiizor/Controls/Button/MaterialFloatingActionButton.cs
+++ b/src/ReaLTaiizor/Controls/Button/MaterialFloatingActionButton.cs
@@ -32,8 +32,44 @@ namespace ReaLTaiizor.Controls
         private const int FAB_ICON_MARGIN = 16;
         private const int FAB_MINI_ICON_MARGIN = 8;
         private const int FAB_ICON_SIZE = 24;
+        private const int ICON_OFFSET = 11;
+        private const int ICON_SIZE = 24;
 
         private bool _mouseHover = false;
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
 
         [DefaultValue(true)]
         [Category("Material"), DisplayName("Draw Shadows")]
@@ -89,7 +125,7 @@ namespace ReaLTaiizor.Controls
             DrawShadows = true;
             SetStyle(ControlStyles.DoubleBuffer | ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true);
 
-            Size = new Size(FAB_SIZE, FAB_SIZE);
+            Size = new Size((int)(FAB_SIZE * ScaleFactor), (int)(FAB_SIZE * ScaleFactor));
             _animationManager = new AnimationManager(false)
             {
                 Increment = 0.03,
@@ -108,11 +144,17 @@ namespace ReaLTaiizor.Controls
 
         protected override void InitLayout()
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             LocationChanged += (sender, e) => { if (DrawShadows) { Parent?.Invalidate(); } };
         }
 
         protected override void OnParentChanged(EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnParentChanged(e);
             if (DrawShadows && Parent != null)
             {
@@ -128,6 +170,14 @@ namespace ReaLTaiizor.Controls
         }
 
         private Control _oldParent;
+
+        protected override void OnDpiChangedAfterParent(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
+            base.OnDpiChangedAfterParent(e);
+        }
 
         protected override void OnVisibleChanged(EventArgs e)
         {
@@ -176,8 +226,8 @@ namespace ReaLTaiizor.Controls
         private void setSize(bool mini)
         {
             _mini = mini;
-            Size = _mini ? new Size(FAB_MINI_SIZE, FAB_MINI_SIZE) : new Size(FAB_SIZE, FAB_SIZE);
-            fabBounds = _mini ? new Rectangle(0, 0, FAB_MINI_SIZE, FAB_MINI_SIZE) : new Rectangle(0, 0, FAB_SIZE, FAB_SIZE);
+            Size = _mini ? new Size((int)(FAB_MINI_SIZE * ScaleFactor), (int)(FAB_MINI_SIZE * ScaleFactor)) : new Size((int)(FAB_SIZE * ScaleFactor), (int)(FAB_SIZE * ScaleFactor));
+            fabBounds = _mini ? new Rectangle(0, 0, (int)(FAB_MINI_SIZE * ScaleFactor), (int)(FAB_MINI_SIZE * ScaleFactor)) : new Rectangle(0, 0, (int)(FAB_SIZE * ScaleFactor), (int)(FAB_SIZE * ScaleFactor));
             fabBounds.Width -= 1;
             fabBounds.Height -= 1;
         }
@@ -248,16 +298,16 @@ namespace ReaLTaiizor.Controls
 
             if (Icon != null)
             {
-                g.DrawImage(Icon, new Rectangle((fabBounds.Width / 2) - 11, (fabBounds.Height / 2) - 11, 24, 24));
+                g.DrawImage(Icon, new Rectangle((fabBounds.Width / 2) - (int)(ICON_OFFSET * ScaleFactor), (fabBounds.Height / 2) - (int)(ICON_OFFSET * ScaleFactor), (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor)));
             }
 
             if (_showAnimationManager.IsAnimating())
             {
-                int target = Convert.ToInt32((_mini ? FAB_MINI_SIZE : FAB_SIZE) * _showAnimationManager.GetProgress());
+                int target = Convert.ToInt32((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) * _showAnimationManager.GetProgress());
                 fabBounds.Width = target == 0 ? 1 : target;
                 fabBounds.Height = target == 0 ? 1 : target;
-                fabBounds.X = Convert.ToInt32(((_mini ? FAB_MINI_SIZE : FAB_SIZE) / 2) - ((_mini ? FAB_MINI_SIZE : FAB_SIZE) / 2 * _showAnimationManager.GetProgress()));
-                fabBounds.Y = Convert.ToInt32(((_mini ? FAB_MINI_SIZE : FAB_SIZE) / 2) - ((_mini ? FAB_MINI_SIZE : FAB_SIZE) / 2 * _showAnimationManager.GetProgress()));
+                fabBounds.X = Convert.ToInt32(((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2) - ((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2 * _showAnimationManager.GetProgress()));
+                fabBounds.Y = Convert.ToInt32(((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2) - ((_mini ? (int)(FAB_MINI_SIZE * ScaleFactor) : (int)(FAB_SIZE * ScaleFactor)) / 2 * _showAnimationManager.GetProgress()));
             }
 
             // Clip to a round shape with a 1px padding
@@ -299,6 +349,9 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnResize(EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnResize(e);
 
             if (DrawShadows && Parent != null)

--- a/src/ReaLTaiizor/Controls/Button/MaterialFloatingActionButton.cs
+++ b/src/ReaLTaiizor/Controls/Button/MaterialFloatingActionButton.cs
@@ -49,10 +49,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -65,10 +63,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         [DefaultValue(true)]

--- a/src/ReaLTaiizor/Controls/Card/MaterialCard.cs
+++ b/src/ReaLTaiizor/Controls/Card/MaterialCard.cs
@@ -25,14 +25,48 @@ namespace ReaLTaiizor.Controls
         [Browsable(false)]
         public MaterialMouseState MouseState { get; set; }
 
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         public MaterialCard()
         {
             SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint | ControlStyles.OptimizedDoubleBuffer | ControlStyles.ResizeRedraw, true);
             Paint += new PaintEventHandler(paintControl);
             BackColor = SkinManager.BackgroundColor;
             ForeColor = SkinManager.TextHighEmphasisColor;
-            Margin = new Padding((int)(SkinManager.FORM_PADDING * GetDeviceScaleFactor()));
-            Padding = new Padding((int)(SkinManager.FORM_PADDING * GetDeviceScaleFactor()));
+            Margin = new Padding((int)(SkinManager.FORM_PADDING * ScaleFactor));
+            Padding = new Padding((int)(SkinManager.FORM_PADDING * ScaleFactor));
         }
 
         private void drawShadowOnParent(object sender, PaintEventArgs e)
@@ -52,7 +86,12 @@ namespace ReaLTaiizor.Controls
 
         protected override void InitLayout()
         {
-            LocationChanged += (sender, e) => { Parent?.Invalidate(); };
+            LocationChanged += (sender, e) => 
+            {
+                ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+                ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this); 
+                Parent?.Invalidate(); 
+            };
             ForeColor = SkinManager.TextHighEmphasisColor;
         }
 
@@ -104,23 +143,10 @@ namespace ReaLTaiizor.Controls
             }
 
             control.Paint += shadowPaintEvent;
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
             control.Invalidate();
             _shadowDrawEventSubscribed = true;
-        }
-
-        private float GetDeviceScaleFactor()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)this.DeviceDpi / 96f;
-            return scalingFactor;
-        }
-
-        private float GetDeviceScaleFactorSqrt()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            return scalingFactor;
         }
 
         private void RemoveShadowPaintEvent(Control control, PaintEventHandler shadowPaintEvent)
@@ -131,6 +157,8 @@ namespace ReaLTaiizor.Controls
             }
 
             control.Paint -= shadowPaintEvent;
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
             control.Invalidate();
             _shadowDrawEventSubscribed = false;
         }

--- a/src/ReaLTaiizor/Controls/Card/MaterialCard.cs
+++ b/src/ReaLTaiizor/Controls/Card/MaterialCard.cs
@@ -31,8 +31,8 @@ namespace ReaLTaiizor.Controls
             Paint += new PaintEventHandler(paintControl);
             BackColor = SkinManager.BackgroundColor;
             ForeColor = SkinManager.TextHighEmphasisColor;
-            Margin = new Padding(SkinManager.FORM_PADDING);
-            Padding = new Padding(SkinManager.FORM_PADDING);
+            Margin = new Padding((int)(SkinManager.FORM_PADDING * GetDeviceScaleFactor()));
+            Padding = new Padding((int)(SkinManager.FORM_PADDING * GetDeviceScaleFactor()));
         }
 
         private void drawShadowOnParent(object sender, PaintEventArgs e)
@@ -106,6 +106,21 @@ namespace ReaLTaiizor.Controls
             control.Paint += shadowPaintEvent;
             control.Invalidate();
             _shadowDrawEventSubscribed = true;
+        }
+
+        private float GetDeviceScaleFactor()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)this.DeviceDpi / 96f;
+            return scalingFactor;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
         }
 
         private void RemoveShadowPaintEvent(Control control, PaintEventHandler shadowPaintEvent)

--- a/src/ReaLTaiizor/Controls/Card/MaterialCard.cs
+++ b/src/ReaLTaiizor/Controls/Card/MaterialCard.cs
@@ -37,10 +37,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -53,10 +51,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public MaterialCard()

--- a/src/ReaLTaiizor/Controls/Card/MaterialCard.cs
+++ b/src/ReaLTaiizor/Controls/Card/MaterialCard.cs
@@ -86,11 +86,11 @@ namespace ReaLTaiizor.Controls
 
         protected override void InitLayout()
         {
-            LocationChanged += (sender, e) => 
+            LocationChanged += (sender, e) =>
             {
                 ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-                ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this); 
-                Parent?.Invalidate(); 
+                ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                Parent?.Invalidate();
             };
             ForeColor = SkinManager.TextHighEmphasisColor;
         }

--- a/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
+++ b/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
@@ -3,10 +3,12 @@
 using ReaLTaiizor.Manager;
 using ReaLTaiizor.Util;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Text;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static ReaLTaiizor.Helper.MaterialDrawHelper;
 using static ReaLTaiizor.Util.MaterialAnimations;
@@ -79,6 +81,7 @@ namespace ReaLTaiizor.Controls
         private static Point[] CheckmarkLine;
         private bool hovered = false;
         private CheckState _oldCheckState;
+        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
         #endregion
 
         #region Constructor
@@ -132,6 +135,7 @@ namespace ReaLTaiizor.Controls
             base.OnSizeChanged(e);
             
             _boxOffset = ((int)(HEIGHT_RIPPLE * GetDeviceScaleFactor()) / 2) - (int)(9 * GetDeviceScaleFactor());
+            _resizing = false;
         }
 
         protected override void OnTextChanged(EventArgs e)
@@ -386,6 +390,23 @@ namespace ReaLTaiizor.Controls
                 Cursor = IsMouseInCheckArea() ? Cursors.Hand : Cursors.Default;
             };
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Release handle from CreateFont / LogFont
+                foreach (IntPtr handle in LFontToBeReleased)
+                {
+                    if (handle != IntPtr.Zero)
+                    {
+                        DeleteObject(handle);
+                    }
+                }
+                LFontToBeReleased.Clear();
+            }
+            base.Dispose(disposing);
+        }
         #endregion
 
         #region Private events and methods
@@ -393,8 +414,6 @@ namespace ReaLTaiizor.Controls
         {
             // 96 is Windows default scaling DPI（100% scale）
             float scalingFactor = (float)this.DeviceDpi / 96f;
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            // Buttons are not included in sqrt controls.
             return scalingFactor;
         }
 
@@ -429,6 +448,9 @@ namespace ReaLTaiizor.Controls
         {
             return ClientRectangle.Contains(MouseLocation);
         }
+
+        [DllImport("gdi32.dll", ExactSpelling = true)]
+        private static extern bool DeleteObject(IntPtr hObject);
         #endregion
     }
 

--- a/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
+++ b/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
@@ -155,6 +155,7 @@ namespace ReaLTaiizor.Controls
         #region Overridden events
         
         private bool _resizing = false;
+        private int originWidth = 0;
         protected override void OnSizeChanged(EventArgs e)
         {
             if (_resizing)
@@ -164,7 +165,12 @@ namespace ReaLTaiizor.Controls
             }
 
             _resizing = true;
-            Width = (int)(Width * ScaleFactor);
+            if (originWidth != Width) 
+            {
+                Width = (int)(Width * ScaleFactor);
+                originWidth = Width;
+            }
+            
             base.OnSizeChanged(e);
             
             _boxOffset = ((int)(HEIGHT_RIPPLE * ScaleFactor) / 2) - (int)(9 * ScaleFactor);

--- a/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
+++ b/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
@@ -212,8 +212,8 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs pevent)
         {
-            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            // ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            // ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
 
             Graphics g = pevent.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;

--- a/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
+++ b/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
@@ -3,12 +3,10 @@
 using ReaLTaiizor.Manager;
 using ReaLTaiizor.Util;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Text;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static ReaLTaiizor.Helper.MaterialDrawHelper;
 using static ReaLTaiizor.Util.MaterialAnimations;
@@ -153,7 +151,7 @@ namespace ReaLTaiizor.Controls
         #endregion
 
         #region Overridden events
-        
+
         private bool _resizing = false;
         private int originWidth = 0;
         protected override void OnSizeChanged(EventArgs e)
@@ -165,14 +163,14 @@ namespace ReaLTaiizor.Controls
             }
 
             _resizing = true;
-            if (originWidth != Width) 
+            if (originWidth != Width)
             {
                 Width = (int)(Width * ScaleFactor);
                 originWidth = Width;
             }
-            
+
             base.OnSizeChanged(e);
-            
+
             _boxOffset = ((int)(HEIGHT_RIPPLE * ScaleFactor) / 2) - (int)(9 * ScaleFactor);
             _resizing = false;
         }
@@ -294,7 +292,7 @@ namespace ReaLTaiizor.Controls
             // draw checkbox text
             using (MaterialNativeTextRenderer NativeText = new(g))
             {
-                Rectangle textLocation = new(_boxOffset + (int)(TEXT_OFFSET * ScaleFactor), (int)(ScaleFactor), Width - (_boxOffset + (int)(TEXT_OFFSET * ScaleFactor)), (int)(HEIGHT_RIPPLE * ScaleFactor));
+                Rectangle textLocation = new(_boxOffset + (int)(TEXT_OFFSET * ScaleFactor), (int)ScaleFactor, Width - (_boxOffset + (int)(TEXT_OFFSET * ScaleFactor)), (int)(HEIGHT_RIPPLE * ScaleFactor));
                 NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor),
                     Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                     textLocation.Location,

--- a/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
+++ b/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
@@ -81,7 +81,6 @@ namespace ReaLTaiizor.Controls
         private static Point[] CheckmarkLine;
         private bool hovered = false;
         private CheckState _oldCheckState;
-        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
         #endregion
 
         #region Constructor
@@ -393,18 +392,6 @@ namespace ReaLTaiizor.Controls
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                // Release handle from CreateFont / LogFont
-                foreach (IntPtr handle in LFontToBeReleased)
-                {
-                    if (handle != IntPtr.Zero)
-                    {
-                        DeleteObject(handle);
-                    }
-                }
-                LFontToBeReleased.Clear();
-            }
             base.Dispose(disposing);
         }
         #endregion

--- a/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
+++ b/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
@@ -91,10 +91,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -107,10 +105,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
         #endregion
 

--- a/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
+++ b/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
@@ -71,12 +71,12 @@ namespace ReaLTaiizor.Controls
         private readonly AnimationManager _rippleAM;
         private readonly AnimationManager _hoverAM;
         private const int HEIGHT_RIPPLE = 37;
-        private const int HEIGHT_NO_RIPPLE = 20;
+        private const int HEIGHT_NO_RIPPLE = 40;
         private const int TEXT_OFFSET = 26;
         private const int CHECKBOX_SIZE = 18;
         private const int CHECKBOX_SIZE_HALF = CHECKBOX_SIZE / 2;
         private int _boxOffset;
-        private static readonly Point[] CheckmarkLine = { new(3, 8), new(7, 12), new(14, 5) };
+        private static Point[] CheckmarkLine;
         private bool hovered = false;
         private CheckState _oldCheckState;
         #endregion
@@ -112,17 +112,48 @@ namespace ReaLTaiizor.Controls
             _rippleAM.OnAnimationProgress += sender => Invalidate();
 
             Ripple = true;
-            Height = HEIGHT_RIPPLE;
+            Height = (int)(HEIGHT_RIPPLE * GetDeviceScaleFactor());
             MouseLocation = new Point(-1, -1);
         }
         #endregion
 
         #region Overridden events
+        private bool _resizing = false;
         protected override void OnSizeChanged(EventArgs e)
         {
-            base.OnSizeChanged(e);
+            if (_resizing)
+            {
+                base.OnSizeChanged(e);
+                return;
+            }
 
-            _boxOffset = (HEIGHT_RIPPLE / 2) - 9;
+            _resizing = true;
+            Width = (int)(Width * GetDeviceScaleFactor());
+            base.OnSizeChanged(e);
+            
+            _boxOffset = ((int)(HEIGHT_RIPPLE * GetDeviceScaleFactor()) / 2) - (int)(9 * GetDeviceScaleFactor());
+        }
+
+        protected override void OnTextChanged(EventArgs e)
+        {
+            base.OnTextChanged(e);
+            if (AutoSize)
+            {
+                Size = GetPreferredSize(Size.Empty);
+                PerformLayout();
+                Invalidate();
+            }
+        }
+
+        protected override void OnFontChanged(EventArgs e)
+        {
+            base.OnFontChanged(e);
+            if (AutoSize)
+            {
+                Size = GetPreferredSize(Size.Empty);
+                PerformLayout();
+                Invalidate();
+            }
         }
 
         public override Size GetPreferredSize(Size proposedSize)
@@ -134,8 +165,12 @@ namespace ReaLTaiizor.Controls
                 strSize = NativeText.MeasureLogString(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1));
             }
 
-            int w = _boxOffset + TEXT_OFFSET + strSize.Width;
-            return Ripple ? new Size(w, HEIGHT_RIPPLE) : new Size(w, HEIGHT_NO_RIPPLE);
+            float scale = GetDeviceScaleFactor();
+            int boxOffsetLocal = ((int)(HEIGHT_RIPPLE * scale) / 2) - (int)(9 * scale);
+
+            int w = boxOffsetLocal + (int)(TEXT_OFFSET * scale) + strSize.Width;
+            int h = Ripple ? (int)(HEIGHT_RIPPLE * scale) : (int)(HEIGHT_NO_RIPPLE * scale);
+            return new Size(w, h);
         }
 
         protected override void OnPaint(PaintEventArgs pevent)
@@ -147,13 +182,13 @@ namespace ReaLTaiizor.Controls
             // clear the control
             g.Clear(Parent.BackColor == Color.Transparent ? ((Parent.Parent == null || (Parent.Parent != null && Parent.Parent.BackColor == Color.Transparent)) ? SkinManager.BackgroundColor : Parent.Parent.BackColor) : Parent.BackColor);
 
-            int CHECKBOX_CENTER = _boxOffset + CHECKBOX_SIZE_HALF - 1;
+            int CHECKBOX_CENTER = _boxOffset + (int)(CHECKBOX_SIZE_HALF * GetDeviceScaleFactor()) - 1;
             Point animationSource = new(CHECKBOX_CENTER, CHECKBOX_CENTER);
             double animationProgress = _checkAM.GetProgress();
 
             int colorAlpha = Enabled ? (int)(animationProgress * 255.0) : SkinManager.CheckBoxOffDisabledColor.A;
             int backgroundAlpha = Enabled ? (int)(SkinManager.CheckboxOffColor.A * (1.0 - animationProgress)) : SkinManager.CheckBoxOffDisabledColor.A;
-            int rippleHeight = (HEIGHT_RIPPLE % 2 == 0) ? HEIGHT_RIPPLE - 3 : HEIGHT_RIPPLE - 2;
+            int rippleHeight = ((int)(HEIGHT_RIPPLE * GetDeviceScaleFactor()) % 2 == 0) ? (int)(HEIGHT_RIPPLE * GetDeviceScaleFactor()) - 3 : (int)(HEIGHT_RIPPLE * GetDeviceScaleFactor()) - 2;
 
             SolidBrush brush = new(Color.FromArgb(colorAlpha, Enabled ? UseAccentColor ? SkinManager.ColorScheme.AccentColor : SkinManager.ColorScheme.PrimaryColor : SkinManager.CheckBoxOffDisabledColor));
             Pen pen = new(brush.Color, 2);
@@ -182,8 +217,8 @@ namespace ReaLTaiizor.Controls
                 }
             }
 
-            Rectangle checkMarkLineFill = new(_boxOffset, _boxOffset, (int)(CHECKBOX_SIZE * animationProgress), CHECKBOX_SIZE);
-            using (GraphicsPath checkmarkPath = CreateRoundRect(_boxOffset - 0.5f, _boxOffset - 0.5f, CHECKBOX_SIZE, CHECKBOX_SIZE, 1))
+            Rectangle checkMarkLineFill = new(_boxOffset, _boxOffset, (int)((int)(CHECKBOX_SIZE * GetDeviceScaleFactor()) * animationProgress), (int)(CHECKBOX_SIZE * GetDeviceScaleFactor()));
+            using (GraphicsPath checkmarkPath = CreateRoundRect(_boxOffset - 0.5f, _boxOffset - 0.5f, (int)(CHECKBOX_SIZE * GetDeviceScaleFactor()), (int)(CHECKBOX_SIZE * GetDeviceScaleFactor()), 1))
             {
                 if (Enabled)
                 {
@@ -213,8 +248,8 @@ namespace ReaLTaiizor.Controls
             // draw checkbox text
             using (MaterialNativeTextRenderer NativeText = new(g))
             {
-                Rectangle textLocation = new(_boxOffset + TEXT_OFFSET, 0, Width - (_boxOffset + TEXT_OFFSET), HEIGHT_RIPPLE);
-                NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1),
+                Rectangle textLocation = new(_boxOffset + (int)(TEXT_OFFSET * GetDeviceScaleFactor()), (int)(GetDeviceScaleFactor()), Width - (_boxOffset + (int)(TEXT_OFFSET * GetDeviceScaleFactor())), (int)(HEIGHT_RIPPLE * GetDeviceScaleFactor()));
+                NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, GetDeviceScaleFactor()),
                     Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                     textLocation.Location,
                     textLocation.Size,
@@ -234,7 +269,7 @@ namespace ReaLTaiizor.Controls
                 base.AutoSize = value;
                 if (value)
                 {
-                    Size = new Size(10, 10);
+                    Size = GetPreferredSize(Size.Empty);
                 }
             }
         }
@@ -354,13 +389,32 @@ namespace ReaLTaiizor.Controls
         #endregion
 
         #region Private events and methods
+        private float GetDeviceScaleFactor()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)this.DeviceDpi / 96f;
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            // Buttons are not included in sqrt controls.
+            return scalingFactor;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
+        }
+
         private Bitmap DrawCheckMarkBitmap()
         {
-            Bitmap checkMark = new(CHECKBOX_SIZE, CHECKBOX_SIZE);
+            Bitmap checkMark = new((int)(CHECKBOX_SIZE * GetDeviceScaleFactor()), (int)(CHECKBOX_SIZE * GetDeviceScaleFactor()));
             Graphics g = Graphics.FromImage(checkMark);
 
             // clear everything, transparent
             g.Clear(Color.Transparent);
+
+            CheckmarkLine = [new((int)(3 * GetDeviceScaleFactor()), (int)(8 * GetDeviceScaleFactor())), new((int)(7 * GetDeviceScaleFactor()), (int)(12 * GetDeviceScaleFactor())), new((int)(14 * GetDeviceScaleFactor()), (int)(5 * GetDeviceScaleFactor()))];
 
             // draw the checkmark lines
             using (Pen pen = new(Parent.BackColor, 2))

--- a/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
+++ b/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
@@ -81,6 +81,39 @@ namespace ReaLTaiizor.Controls
         private static Point[] CheckmarkLine;
         private bool hovered = false;
         private CheckState _oldCheckState;
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
         #endregion
 
         #region Constructor
@@ -114,12 +147,13 @@ namespace ReaLTaiizor.Controls
             _rippleAM.OnAnimationProgress += sender => Invalidate();
 
             Ripple = true;
-            Height = (int)(HEIGHT_RIPPLE * GetDeviceScaleFactor());
+            Height = (int)(HEIGHT_RIPPLE * ScaleFactor);
             MouseLocation = new Point(-1, -1);
         }
         #endregion
 
         #region Overridden events
+        
         private bool _resizing = false;
         protected override void OnSizeChanged(EventArgs e)
         {
@@ -130,10 +164,10 @@ namespace ReaLTaiizor.Controls
             }
 
             _resizing = true;
-            Width = (int)(Width * GetDeviceScaleFactor());
+            Width = (int)(Width * ScaleFactor);
             base.OnSizeChanged(e);
             
-            _boxOffset = ((int)(HEIGHT_RIPPLE * GetDeviceScaleFactor()) / 2) - (int)(9 * GetDeviceScaleFactor());
+            _boxOffset = ((int)(HEIGHT_RIPPLE * ScaleFactor) / 2) - (int)(9 * ScaleFactor);
             _resizing = false;
         }
 
@@ -168,7 +202,7 @@ namespace ReaLTaiizor.Controls
                 strSize = NativeText.MeasureLogString(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1));
             }
 
-            float scale = GetDeviceScaleFactor();
+            float scale = ScaleFactor;
             int boxOffsetLocal = ((int)(HEIGHT_RIPPLE * scale) / 2) - (int)(9 * scale);
 
             int w = boxOffsetLocal + (int)(TEXT_OFFSET * scale) + strSize.Width;
@@ -178,6 +212,9 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs pevent)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             Graphics g = pevent.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
@@ -185,13 +222,13 @@ namespace ReaLTaiizor.Controls
             // clear the control
             g.Clear(Parent.BackColor == Color.Transparent ? ((Parent.Parent == null || (Parent.Parent != null && Parent.Parent.BackColor == Color.Transparent)) ? SkinManager.BackgroundColor : Parent.Parent.BackColor) : Parent.BackColor);
 
-            int CHECKBOX_CENTER = _boxOffset + (int)(CHECKBOX_SIZE_HALF * GetDeviceScaleFactor()) - 1;
+            int CHECKBOX_CENTER = _boxOffset + (int)(CHECKBOX_SIZE_HALF * ScaleFactor) - 1;
             Point animationSource = new(CHECKBOX_CENTER, CHECKBOX_CENTER);
             double animationProgress = _checkAM.GetProgress();
 
             int colorAlpha = Enabled ? (int)(animationProgress * 255.0) : SkinManager.CheckBoxOffDisabledColor.A;
             int backgroundAlpha = Enabled ? (int)(SkinManager.CheckboxOffColor.A * (1.0 - animationProgress)) : SkinManager.CheckBoxOffDisabledColor.A;
-            int rippleHeight = ((int)(HEIGHT_RIPPLE * GetDeviceScaleFactor()) % 2 == 0) ? (int)(HEIGHT_RIPPLE * GetDeviceScaleFactor()) - 3 : (int)(HEIGHT_RIPPLE * GetDeviceScaleFactor()) - 2;
+            int rippleHeight = ((int)(HEIGHT_RIPPLE * ScaleFactor) % 2 == 0) ? (int)(HEIGHT_RIPPLE * ScaleFactor) - 3 : (int)(HEIGHT_RIPPLE * ScaleFactor) - 2;
 
             SolidBrush brush = new(Color.FromArgb(colorAlpha, Enabled ? UseAccentColor ? SkinManager.ColorScheme.AccentColor : SkinManager.ColorScheme.PrimaryColor : SkinManager.CheckBoxOffDisabledColor));
             Pen pen = new(brush.Color, 2);
@@ -220,8 +257,8 @@ namespace ReaLTaiizor.Controls
                 }
             }
 
-            Rectangle checkMarkLineFill = new(_boxOffset, _boxOffset, (int)((int)(CHECKBOX_SIZE * GetDeviceScaleFactor()) * animationProgress), (int)(CHECKBOX_SIZE * GetDeviceScaleFactor()));
-            using (GraphicsPath checkmarkPath = CreateRoundRect(_boxOffset - 0.5f, _boxOffset - 0.5f, (int)(CHECKBOX_SIZE * GetDeviceScaleFactor()), (int)(CHECKBOX_SIZE * GetDeviceScaleFactor()), 1))
+            Rectangle checkMarkLineFill = new(_boxOffset, _boxOffset, (int)((int)(CHECKBOX_SIZE * ScaleFactor) * animationProgress), (int)(CHECKBOX_SIZE * ScaleFactor));
+            using (GraphicsPath checkmarkPath = CreateRoundRect(_boxOffset - 0.5f, _boxOffset - 0.5f, (int)(CHECKBOX_SIZE * ScaleFactor), (int)(CHECKBOX_SIZE * ScaleFactor), 1))
             {
                 if (Enabled)
                 {
@@ -251,8 +288,8 @@ namespace ReaLTaiizor.Controls
             // draw checkbox text
             using (MaterialNativeTextRenderer NativeText = new(g))
             {
-                Rectangle textLocation = new(_boxOffset + (int)(TEXT_OFFSET * GetDeviceScaleFactor()), (int)(GetDeviceScaleFactor()), Width - (_boxOffset + (int)(TEXT_OFFSET * GetDeviceScaleFactor())), (int)(HEIGHT_RIPPLE * GetDeviceScaleFactor()));
-                NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, GetDeviceScaleFactor()),
+                Rectangle textLocation = new(_boxOffset + (int)(TEXT_OFFSET * ScaleFactor), (int)(ScaleFactor), Width - (_boxOffset + (int)(TEXT_OFFSET * ScaleFactor)), (int)(HEIGHT_RIPPLE * ScaleFactor));
+                NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor),
                     Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                     textLocation.Location,
                     textLocation.Size,
@@ -397,30 +434,15 @@ namespace ReaLTaiizor.Controls
         #endregion
 
         #region Private events and methods
-        private float GetDeviceScaleFactor()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)this.DeviceDpi / 96f;
-            return scalingFactor;
-        }
-
-        private float GetDeviceScaleFactorSqrt()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            return scalingFactor;
-        }
-
         private Bitmap DrawCheckMarkBitmap()
         {
-            Bitmap checkMark = new((int)(CHECKBOX_SIZE * GetDeviceScaleFactor()), (int)(CHECKBOX_SIZE * GetDeviceScaleFactor()));
+            Bitmap checkMark = new((int)(CHECKBOX_SIZE * ScaleFactor), (int)(CHECKBOX_SIZE * ScaleFactor));
             Graphics g = Graphics.FromImage(checkMark);
 
             // clear everything, transparent
             g.Clear(Color.Transparent);
 
-            CheckmarkLine = [new((int)(3 * GetDeviceScaleFactor()), (int)(8 * GetDeviceScaleFactor())), new((int)(7 * GetDeviceScaleFactor()), (int)(12 * GetDeviceScaleFactor())), new((int)(14 * GetDeviceScaleFactor()), (int)(5 * GetDeviceScaleFactor()))];
+            CheckmarkLine = [new((int)(3 * ScaleFactor), (int)(8 * ScaleFactor)), new((int)(7 * ScaleFactor), (int)(12 * ScaleFactor)), new((int)(14 * ScaleFactor), (int)(5 * ScaleFactor))];
 
             // draw the checkmark lines
             using (Pen pen = new(Parent.BackColor, 2))
@@ -436,8 +458,6 @@ namespace ReaLTaiizor.Controls
             return ClientRectangle.Contains(MouseLocation);
         }
 
-        [DllImport("gdi32.dll", ExactSpelling = true)]
-        private static extern bool DeleteObject(IntPtr hObject);
         #endregion
     }
 

--- a/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
+++ b/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
@@ -251,6 +251,7 @@ namespace ReaLTaiizor.Controls
             PointF TopRight = new(this.Width - (0.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) - (2.5f * ScaleFactor));
             PointF MidBottom = new(this.Width - (4.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) + (2.5f * ScaleFactor));
             PointF TopLeft = new(this.Width - (8.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) - (2.5f * ScaleFactor));
+            
             // TODO: The arrow coordinates use magic numbers; consider refactoring while preserving the current visual layout.
             pth.AddLine(TopLeft, TopRight);
             pth.AddLine(TopRight, MidBottom);

--- a/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
+++ b/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
@@ -92,10 +92,53 @@ namespace ReaLTaiizor.Controls
         private const int TEXT_SMALL_SIZE = 18;
         private const int TEXT_SMALL_Y = 4;
         private const int BOTTOM_PADDING = 3;
+        private const int DEFAULT_HEIGHT = 50; // DO NOT REPLACE WITH RATIO FORMULA
+        private const int HEIGHT_NOT_TALL = 36; // DO NOT REPLACE WITH RATIO FORMULA
+        private const int PADDING_CONST = 7;
+        private const int DROPDOWN_PADDING = 2;
+        private const int HINTRECT_PADDING = 2;
+        private const int INDICATOR_HEIGHT = 2;
+        private const int CLIENT_PADDING = 8;
         private int HEIGHT = 50;
         private int LINE_Y;
 
+        int hintTextSize = 16;
+
         private bool hasHint;
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
 
         private readonly AnimationManager _animationManager;
 
@@ -109,7 +152,7 @@ namespace ReaLTaiizor.Controls
             UseTallSize = true;
             MaxDropDownItems = 4;
 
-            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle2);
+            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle2, ScaleFactor);
             BackColor = SkinManager.BackgroundColor;
             ForeColor = SkinManager.TextHighEmphasisColor;
             DrawMode = DrawMode.OwnerDrawVariable;
@@ -173,6 +216,14 @@ namespace ReaLTaiizor.Controls
             };
         }
 
+        protected override void OnDpiChangedAfterParent(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
+            base.OnDpiChangedAfterParent(e);
+        }
+
         protected override void OnPaint(PaintEventArgs pevent)
         {
             Graphics g = pevent.Graphics;
@@ -201,9 +252,11 @@ namespace ReaLTaiizor.Controls
 
             // Create and Draw the arrow
             GraphicsPath pth = new();
-            PointF TopRight = new(this.Width - 0.5f - SkinManager.FORM_PADDING, (this.Height >> 1) - 2.5f);
-            PointF MidBottom = new(this.Width - 4.5f - SkinManager.FORM_PADDING, (this.Height >> 1) + 2.5f);
-            PointF TopLeft = new(this.Width - 8.5f - SkinManager.FORM_PADDING, (this.Height >> 1) - 2.5f);
+            PointF TopRight = new(this.Width - 0.5f * ScaleFactor - SkinManager.FORM_PADDING, (this.Height >> 1) - 2.5f * ScaleFactor);
+            PointF MidBottom = new(this.Width - 4.5f * ScaleFactor - SkinManager.FORM_PADDING, (this.Height >> 1) + 2.5f * ScaleFactor);
+            PointF TopLeft = new(this.Width - 8.5f * ScaleFactor - SkinManager.FORM_PADDING, (this.Height >> 1) - 2.5f * ScaleFactor);
+            // Magic numbers warning
+#warning Magic Numbers
             pth.AddLine(TopLeft, TopRight);
             pth.AddLine(TopRight, MidBottom);
 
@@ -218,10 +271,9 @@ namespace ReaLTaiizor.Controls
             // HintText
             bool userTextPresent = SelectedIndex >= 0;
             Rectangle hintRect = new(SkinManager.FORM_PADDING, ClientRectangle.Y, Width, LINE_Y);
-            int hintTextSize = 16;
 
             // bottom line base
-            g.FillRectangle(SkinManager.DividersAlternativeBrush, 0, LINE_Y, Width, 1);
+            g.FillRectangle(SkinManager.DividersAlternativeBrush, 0, LINE_Y, Width, (int)(INDICATOR_HEIGHT) / 2);
 
             if (!_animationManager.IsAnimating())
             {
@@ -229,14 +281,14 @@ namespace ReaLTaiizor.Controls
                 if (hasHint && UseTallSize && (DroppedDown || Focused || SelectedIndex >= 0))
                 {
                     // hint text
-                    hintRect = new Rectangle(SkinManager.FORM_PADDING, TEXT_SMALL_Y, Width, TEXT_SMALL_SIZE);
+                    hintRect = new Rectangle(SkinManager.FORM_PADDING, (int)(TEXT_SMALL_Y * ScaleFactor), Width, (int)(TEXT_SMALL_SIZE * ScaleFactor));
                     hintTextSize = 12;
                 }
 
                 // bottom line
                 if (DroppedDown || Focused)
                 {
-                    g.FillRectangle(SelectedBrush, 0, LINE_Y, Width, 2);
+                    g.FillRectangle(SelectedBrush, 0, LINE_Y, Width, (int)(INDICATOR_HEIGHT * ScaleFactor));
                 }
             }
             else
@@ -249,23 +301,23 @@ namespace ReaLTaiizor.Controls
                 {
                     hintRect = new Rectangle(
                         SkinManager.FORM_PADDING,
-                        userTextPresent && !_animationManager.IsAnimating() ? TEXT_SMALL_Y : ClientRectangle.Y + (int)((TEXT_SMALL_Y - ClientRectangle.Y) * animationProgress),
+                        userTextPresent && !_animationManager.IsAnimating() ? (int)(TEXT_SMALL_Y * ScaleFactor) : ClientRectangle.Y + (int)(((int)(TEXT_SMALL_Y * ScaleFactor) - ClientRectangle.Y) * animationProgress),
                         Width,
-                        userTextPresent && !_animationManager.IsAnimating() ? TEXT_SMALL_SIZE : (int)(LINE_Y + ((TEXT_SMALL_SIZE - LINE_Y) * animationProgress)));
+                        userTextPresent && !_animationManager.IsAnimating() ? (int)(TEXT_SMALL_SIZE * ScaleFactor) : (int)(LINE_Y + (((int)(TEXT_SMALL_SIZE * ScaleFactor) - LINE_Y) * animationProgress)));
                     hintTextSize = userTextPresent && !_animationManager.IsAnimating() ? 12 : (int)(16 + ((12 - 16) * animationProgress));
                 }
 
                 // Line Animation
                 int LineAnimationWidth = (int)(Width * animationProgress);
                 int LineAnimationX = (Width / 2) - (LineAnimationWidth / 2);
-                g.FillRectangle(SelectedBrush, LineAnimationX, LINE_Y, LineAnimationWidth, 2);
+                g.FillRectangle(SelectedBrush, LineAnimationX, LINE_Y, LineAnimationWidth, (int)(INDICATOR_HEIGHT * ScaleFactor));
             }
 
             // Calc text Rect
             Rectangle textRect = new(
                 SkinManager.FORM_PADDING,
-                hasHint && UseTallSize ? hintRect.Y + hintRect.Height - 2 : ClientRectangle.Y,
-                ClientRectangle.Width - (SkinManager.FORM_PADDING * 3) - 8,
+                hasHint && UseTallSize ? hintRect.Y + hintRect.Height - (int)(HINTRECT_PADDING * ScaleFactor) : ClientRectangle.Y,
+                ClientRectangle.Width - (SkinManager.FORM_PADDING * 3) - (int)((int)(CLIENT_PADDING * ScaleFactor) * ScaleFactor),
                 hasHint && UseTallSize ? LINE_Y - (hintRect.Y + hintRect.Height) : LINE_Y);
 
             g.Clip = new Region(textRect);
@@ -275,7 +327,7 @@ namespace ReaLTaiizor.Controls
                 // Draw user text
                 NativeText.DrawTransparentText(
                     Text,
-                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1),
+                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor),
                     Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                     textRect.Location,
                     textRect.Size,
@@ -290,7 +342,7 @@ namespace ReaLTaiizor.Controls
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                 Hint,
-                SkinManager.GetTextBoxFontBySize(hintTextSize),
+                SkinManager.GetTextBoxFontBySize(hintTextSize, ScaleFactor),
                 Enabled ? DroppedDown || Focused ?
                 SelectedColor : // Focus 
                 SkinManager.TextMediumEmphasisColor : // not focused
@@ -303,7 +355,7 @@ namespace ReaLTaiizor.Controls
 
         private void CustomMeasureItem(object sender, MeasureItemEventArgs e)
         {
-            e.ItemHeight = HEIGHT - 7;
+            e.ItemHeight = (int)(HEIGHT * ScaleFactor) - (int)(PADDING_CONST * ScaleFactor);
         }
 
         private void CustomDrawItem(object sender, DrawItemEventArgs e)
@@ -346,7 +398,7 @@ namespace ReaLTaiizor.Controls
             using MaterialNativeTextRenderer NativeText = new(g);
             NativeText.DrawTransparentText(
             Text,
-            SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1),
+            SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor),
             SkinManager.TextHighEmphasisNoAlphaColor,
             new Point(e.Bounds.Location.X + SkinManager.FORM_PADDING, e.Bounds.Location.Y),
             new Size(e.Bounds.Size.Width - (SkinManager.FORM_PADDING * 2), e.Bounds.Size.Height),
@@ -367,6 +419,9 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnResize(EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnResize(e);
             recalculateAutoSize();
             setHeightVars();
@@ -374,11 +429,11 @@ namespace ReaLTaiizor.Controls
 
         private void setHeightVars()
         {
-            HEIGHT = UseTallSize ? 50 : 36;
-            Size = new Size(Size.Width, HEIGHT);
-            LINE_Y = HEIGHT - BOTTOM_PADDING;
-            ItemHeight = HEIGHT - 7;
-            DropDownHeight = (ItemHeight * MaxDropDownItems) + 2;
+            HEIGHT = UseTallSize ? DEFAULT_HEIGHT : HEIGHT_NOT_TALL;
+            Size = new Size(Size.Width, (int)(HEIGHT * ScaleFactor));
+            LINE_Y = Height - INDICATOR_HEIGHT;
+            ItemHeight = (int)(HEIGHT * ScaleFactor) - (int)(PADDING_CONST * ScaleFactor);
+            DropDownHeight = (ItemHeight * MaxDropDownItems) + (int)(DROPDOWN_PADDING * ScaleFactor);
         }
 
         public void recalculateAutoSize()
@@ -398,7 +453,7 @@ namespace ReaLTaiizor.Controls
                 System.Collections.Generic.IEnumerable<string> itemsList = this.Items.Cast<object>().Select(item => item.ToString());
                 foreach (string s in itemsList)
                 {
-                    int newWidth = NativeText.MeasureLogString(s, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1)).Width + vertScrollBarWidth + padding;
+                    int newWidth = NativeText.MeasureLogString(s, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor)).Width + vertScrollBarWidth + padding;
                     if (w < newWidth)
                     {
                         w = newWidth;

--- a/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
+++ b/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
@@ -252,9 +252,9 @@ namespace ReaLTaiizor.Controls
 
             // Create and Draw the arrow
             GraphicsPath pth = new();
-            PointF TopRight = new(this.Width - 0.5f * ScaleFactor - SkinManager.FORM_PADDING, (this.Height >> 1) - 2.5f * ScaleFactor);
-            PointF MidBottom = new(this.Width - 4.5f * ScaleFactor - SkinManager.FORM_PADDING, (this.Height >> 1) + 2.5f * ScaleFactor);
-            PointF TopLeft = new(this.Width - 8.5f * ScaleFactor - SkinManager.FORM_PADDING, (this.Height >> 1) - 2.5f * ScaleFactor);
+            PointF TopRight = new(this.Width - (0.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) - (2.5f * ScaleFactor));
+            PointF MidBottom = new(this.Width - (4.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) + (2.5f * ScaleFactor));
+            PointF TopLeft = new(this.Width - (8.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) - (2.5f * ScaleFactor));
             // Magic numbers warning
 #warning Magic Numbers
             pth.AddLine(TopLeft, TopRight);
@@ -273,7 +273,7 @@ namespace ReaLTaiizor.Controls
             Rectangle hintRect = new(SkinManager.FORM_PADDING, ClientRectangle.Y, Width, LINE_Y);
 
             // bottom line base
-            g.FillRectangle(SkinManager.DividersAlternativeBrush, 0, LINE_Y, Width, (int)(INDICATOR_HEIGHT) / 2);
+            g.FillRectangle(SkinManager.DividersAlternativeBrush, 0, LINE_Y, Width, (int)INDICATOR_HEIGHT / 2);
 
             if (!_animationManager.IsAnimating())
             {

--- a/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
+++ b/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
@@ -251,7 +251,7 @@ namespace ReaLTaiizor.Controls
             PointF TopRight = new(this.Width - (0.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) - (2.5f * ScaleFactor));
             PointF MidBottom = new(this.Width - (4.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) + (2.5f * ScaleFactor));
             PointF TopLeft = new(this.Width - (8.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) - (2.5f * ScaleFactor));
-            
+
             // TODO: The arrow coordinates use magic numbers; consider refactoring while preserving the current visual layout.
             pth.AddLine(TopLeft, TopRight);
             pth.AddLine(TopRight, MidBottom);

--- a/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
+++ b/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
@@ -251,8 +251,7 @@ namespace ReaLTaiizor.Controls
             PointF TopRight = new(this.Width - (0.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) - (2.5f * ScaleFactor));
             PointF MidBottom = new(this.Width - (4.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) + (2.5f * ScaleFactor));
             PointF TopLeft = new(this.Width - (8.5f * ScaleFactor) - SkinManager.FORM_PADDING, (this.Height >> 1) - (2.5f * ScaleFactor));
-            // Magic numbers warning
-#warning Magic Numbers
+            // TODO: The arrow coordinates use magic numbers; consider refactoring while preserving the current visual layout.
             pth.AddLine(TopLeft, TopRight);
             pth.AddLine(TopRight, MidBottom);
 

--- a/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
+++ b/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
@@ -313,7 +313,7 @@ namespace ReaLTaiizor.Controls
             Rectangle textRect = new(
                 SkinManager.FORM_PADDING,
                 hasHint && UseTallSize ? hintRect.Y + hintRect.Height - (int)(HINTRECT_PADDING * ScaleFactor) : ClientRectangle.Y,
-                ClientRectangle.Width - (SkinManager.FORM_PADDING * 3) - (int)((int)(CLIENT_PADDING * ScaleFactor) * ScaleFactor),
+                ClientRectangle.Width - (SkinManager.FORM_PADDING * 3) - (int)(CLIENT_PADDING * ScaleFactor),
                 hasHint && UseTallSize ? LINE_Y - (hintRect.Y + hintRect.Height) : LINE_Y);
 
             g.Clip = new Region(textRect);

--- a/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
+++ b/src/ReaLTaiizor/Controls/ComboBox/MaterialComboBox.cs
@@ -118,10 +118,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -134,10 +132,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         private readonly AnimationManager _animationManager;

--- a/src/ReaLTaiizor/Controls/Dialog/MaterialDialog.cs
+++ b/src/ReaLTaiizor/Controls/Dialog/MaterialDialog.cs
@@ -25,6 +25,8 @@ namespace ReaLTaiizor.Controls
         private const int BUTTON_HEIGHT = 36;
         private const int TEXT_TOP_PADDING = 17;
         private const int TEXT_BOTTOM_PADDING = 28;
+        private const int MSG_BOX_WIDTH = 560;
+        private int FONT_HEIGHT = 19; // Need to be changed with Font..
         private int _header_Height = 40;
 
         private MaterialButton _validationButton = new();
@@ -36,6 +38,40 @@ namespace ReaLTaiizor.Controls
         private string _title;
 
         //public ObservableCollection<MaterialButton> Buttons { get; set; }
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
 
         [DllImport("Gdi32.dll", EntryPoint = "CreateRoundRectRgn")]
         private static extern IntPtr CreateRoundRectRgn
@@ -125,29 +161,29 @@ namespace ReaLTaiizor.Controls
                 Controls.Add(_cancelButton);
             }
 
-            Width = 560;
-            int TextWidth = TextRenderer.MeasureText(_text, SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1)).Width;
-            int RectWidth = Width - (2 * LEFT_RIGHT_PADDING) - BUTTON_PADDING;
-            int RectHeight = ((TextWidth / RectWidth) + 1) * 19;
+            Width = (int)(MSG_BOX_WIDTH * ScaleFactor);
+            int TextWidth = TextRenderer.MeasureText(_text, SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor)).Width;
+            int RectWidth = Width - (2 * (int)(LEFT_RIGHT_PADDING * ScaleFactor)) - (int)(BUTTON_PADDING * ScaleFactor);
+            int RectHeight = ((TextWidth / RectWidth) + 1) * (int)(FONT_HEIGHT * ScaleFactor);
             Rectangle textRect = new(
-                LEFT_RIGHT_PADDING,
-                _header_Height + TEXT_TOP_PADDING,
+                (int)(LEFT_RIGHT_PADDING * ScaleFactor),
+                (int)(_header_Height * ScaleFactor) + (int)(TEXT_TOP_PADDING * ScaleFactor),
                 RectWidth,
                 RectHeight + 9);
 
-            Height = _header_Height + TEXT_TOP_PADDING + textRect.Height + TEXT_BOTTOM_PADDING + 52; //560;
+            Height = (int)(_header_Height * ScaleFactor) + (int)(TEXT_TOP_PADDING * ScaleFactor) + textRect.Height + (int)(TEXT_BOTTOM_PADDING * ScaleFactor) + 52; //560;
             Region = Region.FromHrgn(CreateRoundRectRgn(0, 0, Width, Height, 6, 6));
 
-            int _buttonWidth = TextRenderer.MeasureText(ValidationButtonText, SkinManager.GetFontByType(MaterialSkinManager.FontType.Button)).Width + 32;
-            Rectangle _validationbuttonBounds = new(Width - BUTTON_PADDING - _buttonWidth, Height - BUTTON_PADDING - BUTTON_HEIGHT, _buttonWidth, BUTTON_HEIGHT);
+            int _buttonWidth = TextRenderer.MeasureText(ValidationButtonText, SkinManager.GetFontByType(MaterialSkinManager.FontType.Button, ScaleFactor)).Width + 32;
+            Rectangle _validationbuttonBounds = new(Width - (int)(BUTTON_PADDING * ScaleFactor) - _buttonWidth, Height - (int)(BUTTON_PADDING * ScaleFactor) - (int)(BUTTON_HEIGHT * ScaleFactor), _buttonWidth, (int)(BUTTON_HEIGHT * ScaleFactor));
             _validationButton.Width = _validationbuttonBounds.Width;
             _validationButton.Height = _validationbuttonBounds.Height;
             _validationButton.Top = _validationbuttonBounds.Top;
             _validationButton.Left = _validationbuttonBounds.Left;  //Button minimum width management
             _validationButton.Visible = true;
 
-            _buttonWidth = TextRenderer.MeasureText(CancelButtonText, SkinManager.GetFontByType(MaterialSkinManager.FontType.Button)).Width + 32;
-            Rectangle _cancelbuttonBounds = new(_validationbuttonBounds.Left - BUTTON_PADDING - _buttonWidth, Height - BUTTON_PADDING - BUTTON_HEIGHT, _buttonWidth, BUTTON_HEIGHT);
+            _buttonWidth = TextRenderer.MeasureText(CancelButtonText, SkinManager.GetFontByType(MaterialSkinManager.FontType.Button, ScaleFactor)).Width + 32;
+            Rectangle _cancelbuttonBounds = new(_validationbuttonBounds.Left - (int)(BUTTON_PADDING * ScaleFactor) - _buttonWidth, Height - (int)(BUTTON_PADDING * ScaleFactor) - (int)(BUTTON_HEIGHT * ScaleFactor), _buttonWidth, (int)(BUTTON_HEIGHT * ScaleFactor));
             _cancelButton.Width = _cancelbuttonBounds.Width;
             _cancelButton.Height = _cancelbuttonBounds.Height;
             _cancelButton.Top = _cancelbuttonBounds.Top;
@@ -188,6 +224,9 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnLoad(EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnLoad(e);
 
             Location = new Point(Convert.ToInt32(Owner.Location.X + (Owner.Width / 2) - (Width / 2)), Convert.ToInt32(Owner.Location.Y + (Owner.Height / 2) - (Height / 2)));
@@ -204,6 +243,8 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
 
             Graphics g = e.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;
@@ -212,10 +253,10 @@ namespace ReaLTaiizor.Controls
 
             // Calc title Rect
             Rectangle titleRect = new(
-                LEFT_RIGHT_PADDING,
+                (int)(LEFT_RIGHT_PADDING * ScaleFactor),
                 0,
-                Width - (2 * LEFT_RIGHT_PADDING),
-                _header_Height);
+                Width - (2 * (int)(LEFT_RIGHT_PADDING * ScaleFactor)),
+                (int)(_header_Height * ScaleFactor));
 
             //Draw title
             using (MaterialNativeTextRenderer NativeText = new(g))
@@ -223,7 +264,7 @@ namespace ReaLTaiizor.Controls
                 // Draw header text
                 NativeText.DrawTransparentText(
                     _title,
-                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6),
+                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6, ScaleFactor),
                     SkinManager.TextHighEmphasisColor,
                     titleRect.Location,
                     titleRect.Size,
@@ -232,15 +273,15 @@ namespace ReaLTaiizor.Controls
 
             // Calc text Rect
 
-            int TextWidth = TextRenderer.MeasureText(_text, SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1)).Width;
-            int RectWidth = Width - (2 * LEFT_RIGHT_PADDING) - BUTTON_PADDING;
-            int RectHeight = ((TextWidth / RectWidth) + 1) * 19;
+            int TextWidth = TextRenderer.MeasureText(_text, SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor)).Width;
+            int RectWidth = Width - (2 * (int)(LEFT_RIGHT_PADDING * ScaleFactor)) - (int)(BUTTON_PADDING * ScaleFactor);
+            int RectHeight = ((TextWidth / RectWidth) + 1) * (int)(FONT_HEIGHT * ScaleFactor);
 
             Rectangle textRect = new(
-                LEFT_RIGHT_PADDING,
-                _header_Height + 17,
+                (int)(LEFT_RIGHT_PADDING * ScaleFactor),
+                (int)(_header_Height * ScaleFactor) + (int)(TEXT_TOP_PADDING * ScaleFactor),
                 RectWidth,
-                RectHeight + 19);
+                RectHeight + (int)(FONT_HEIGHT * ScaleFactor));
 
             //Draw  Text
             using (MaterialNativeTextRenderer NativeText = new(g))
@@ -248,7 +289,7 @@ namespace ReaLTaiizor.Controls
                 // Draw header text
                 NativeText.DrawMultilineTransparentText(
                     _text,
-                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1),
+                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor),
                     SkinManager.TextHighEmphasisColor,
                     textRect.Location,
                     textRect.Size,
@@ -257,7 +298,7 @@ namespace ReaLTaiizor.Controls
 
         }
 
-        protected override void OnClosing(CancelEventArgs e)
+        protected override void OnFormClosing(FormClosingEventArgs e)
         {
             _formOverlay.Visible = false;
             _formOverlay.Close();
@@ -265,7 +306,7 @@ namespace ReaLTaiizor.Controls
 
             DialogResult res = this.DialogResult;
 
-            base.OnClosing(e);
+            base.OnFormClosing(e);
         }
 
         void _AnimationManager_OnAnimationFinished(object sender)
@@ -285,8 +326,11 @@ namespace ReaLTaiizor.Controls
 
         private void InitializeComponent()
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             this.SuspendLayout();
-            this.ClientSize = new Size(560, 182);
+            this.ClientSize = new Size((int)(MSG_BOX_WIDTH * ScaleFactor), 182);
             this.Name = "Dialog";
             this.ResumeLayout(false);
 

--- a/src/ReaLTaiizor/Controls/Dialog/MaterialDialog.cs
+++ b/src/ReaLTaiizor/Controls/Dialog/MaterialDialog.cs
@@ -5,7 +5,6 @@ using ReaLTaiizor.Forms;
 using ReaLTaiizor.Manager;
 using ReaLTaiizor.Util;
 using System;
-using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Runtime.InteropServices;

--- a/src/ReaLTaiizor/Controls/Dialog/MaterialDialog.cs
+++ b/src/ReaLTaiizor/Controls/Dialog/MaterialDialog.cs
@@ -50,10 +50,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -66,10 +64,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         [DllImport("Gdi32.dll", EntryPoint = "CreateRoundRectRgn")]

--- a/src/ReaLTaiizor/Controls/Drawer/MaterialDrawer.cs
+++ b/src/ReaLTaiizor/Controls/Drawer/MaterialDrawer.cs
@@ -336,30 +336,49 @@ namespace ReaLTaiizor.Controls
                 // Image Rect
                 Rectangle destRect = new(0, 0, ShowTabControl.ImageList.Images[tabPage.ImageKey].Width, ShowTabControl.ImageList.Images[tabPage.ImageKey].Height);
 
-                // Create a pre-processed copy of the image (GRAY)
-                Bitmap bgray = new(destRect.Width, destRect.Height);
+                // 1.Obtain the original icon dimensions and calculate the scaled physical dimensions.
+                Image originalImg = ShowTabControl.ImageList.Images[tabPage.ImageKey];
+                int sW = (int)(originalImg.Width * ScaleFactor);
+                int sH = (int)(originalImg.Height * ScaleFactor);
+
+                Bitmap bgray = new(sW, sH); // Create a sufficiently large bitmap
                 using (Graphics gGray = Graphics.FromImage(bgray))
                 {
-                    gGray.DrawImage(ShowTabControl.ImageList.Images[tabPage.ImageKey],
-                        new Point[] {
-                                new(0, 0),
-                                new(destRect.Width, 0),
-                                new(0, destRect.Height),
-                        },
-                        destRect, GraphicsUnit.Pixel, grayImageAttributes);
+                    gGray.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                    gGray.Clear(Color.Transparent); // Clear Bg
+
+                    // Here 'destRect' is target region on bitmap
+                    Rectangle destRectScaled = new(0, 0, sW, sH);
+
+                    gGray.DrawImage(
+                        originalImg,
+                        destRectScaled,
+                        0, 0,
+                        originalImg.Width,
+                        originalImg.Height,
+                        GraphicsUnit.Pixel,
+                        grayImageAttributes
+                        );  
                 }
 
                 // Create a pre-processed copy of the image (PRIMARY COLOR)
-                Bitmap bcolor = new(destRect.Width, destRect.Height);
+                Bitmap bcolor = new(sW, sH);
                 using (Graphics gColor = Graphics.FromImage(bcolor))
                 {
-                    gColor.DrawImage(ShowTabControl.ImageList.Images[tabPage.ImageKey],
-                        new Point[] {
-                                new(0, 0),
-                                new(destRect.Width, 0),
-                                new(0, destRect.Height),
-                        },
-                        destRect, GraphicsUnit.Pixel, colorImageAttributes);
+                    gColor.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                    gColor.Clear(Color.Transparent); 
+
+                    Rectangle destRectScaled = new(0, 0, sW, sH);
+
+                    gColor.DrawImage(
+                        originalImg,
+                        destRectScaled,
+                        0, 0,
+                        originalImg.Width,
+                        originalImg.Height,
+                        GraphicsUnit.Pixel,
+                        colorImageAttributes
+                        ); 
                 }
 
                 // added processed image to brush for drawing
@@ -384,9 +403,22 @@ namespace ReaLTaiizor.Controls
 
                 // add to dictionary
                 string ik = string.Concat(tabPage.ImageKey, "_", tabPage.Name);
-                iconsBrushes.Add(ik, textureBrushGray);
-                iconsSelectedBrushes.Add(ik, textureBrushColor);
-                iconsSize.Add(ik, new Rectangle(0, 0, iconRect.Width, iconRect.Height));
+                TextureBrush tBrush = new TextureBrush(bgray);
+                tBrush.WrapMode = WrapMode.Clamp;
+                TextureBrush tBrushColor = new TextureBrush(bcolor);
+                tBrushColor.WrapMode = WrapMode.Clamp;
+                // calc center positions.
+                float x = _drawerItemRects[currentTabIndex].X + (drawerItemHeight / 2.0f) - (sW / 2.0f);
+                float y = _drawerItemRects[currentTabIndex].Y + (drawerItemHeight / 2.0f) - (sH / 2.0f);
+
+                tBrush.TranslateTransform(x, y);
+                iconsBrushes.Add(ik, tBrush);
+                tBrushColor.TranslateTransform(x, y);
+                iconsSelectedBrushes.Add(ik, tBrushColor);
+
+                //iconsBrushes.Add(ik, textureBrushGray);
+                //iconsSelectedBrushes.Add(ik, textureBrushColor);
+                iconsSize.Add(ik, new Rectangle(0, 0, (int)(iconRect.Width * ScaleFactor), (int)(iconRect.Height * ScaleFactor)));
             }
         }
 
@@ -409,6 +441,40 @@ namespace ReaLTaiizor.Controls
         public int MinWidth;
         private int _lastMouseY;
         private int _lastLocationY;
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
 
         public MaterialDrawer()
         {
@@ -494,7 +560,7 @@ namespace ReaLTaiizor.Controls
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected override void InitLayout()
         {
-            drawerItemHeight = (TAB_HEADER_PADDING * 2) - (SkinManager.FORM_PADDING / 2);
+            drawerItemHeight = ((int)(TAB_HEADER_PADDING * ScaleFactor) * 2) - (SkinManager.FORM_PADDING / 2);
             MinWidth = (int)((SkinManager.FORM_PADDING * 1.5) + drawerItemHeight);
             _showHideAnimManager.SetProgress(_isOpen ? 0 : 1);
             showHideAnimation();
@@ -538,8 +604,17 @@ namespace ReaLTaiizor.Controls
             UpdateTabRects();
         }
 
+        protected override void OnDpiChangedAfterParent(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            base.OnDpiChangedAfterParent(e);
+        }
+
         protected override void OnPaint(PaintEventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
             Paint(e);
         }
 
@@ -597,7 +672,7 @@ namespace ReaLTaiizor.Controls
                 // Background
                 Brush bgBrush = new SolidBrush(Color.FromArgb(CalculateAlpha(60, 0, currentTabIndex, clickAnimProgress, 1 - showHideAnimProgress),
                     UseColors ? BackgroundWithAccent ? SkinManager.ColorScheme.AccentColor : SkinManager.ColorScheme.LightPrimaryColor : // using colors
-                    BackgroundWithAccent ? SkinManager.ColorScheme.AccentColor : // defaul accent
+                    BackgroundWithAccent ? SkinManager.ColorScheme.AccentColor : // default accent
                     SkinManager.Theme == MaterialSkinManager.Themes.LIGHT ? SkinManager.ColorScheme.PrimaryColor : // default light
                     SkinManager.ColorScheme.LightPrimaryColor)); // default dark
                 g.FillPath(bgBrush, _drawerItemPaths[currentTabIndex]);
@@ -610,7 +685,7 @@ namespace ReaLTaiizor.Controls
                     (currentTabIndex == ShowTabControl.SelectedIndex ? (HighlightWithAccent ? SkinManager.ColorScheme.AccentColor : SkinManager.ColorScheme.PrimaryColor) : // selected
                     SkinManager.TextHighEmphasisColor));
 
-                IntPtr textFont = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2);
+                IntPtr textFont = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2, ScaleFactor);
 
                 Rectangle textRect = _drawerItemRects[currentTabIndex];
                 textRect.X += ShowTabControl.ImageList != null ? drawerItemHeight : (int)(SkinManager.FORM_PADDING * 0.75);
@@ -838,9 +913,9 @@ namespace ReaLTaiizor.Controls
 
             Cursor = previousCursor;
 
-            if (e.Location.X + this.Location.X < BORDER_WIDTH)
+            if (e.Location.X + this.Location.X < (int)(BORDER_WIDTH * ScaleFactor))
             {
-                if (e.Location.Y > this.Height - BORDER_WIDTH)
+                if (e.Location.Y > this.Height - (int)(BORDER_WIDTH * ScaleFactor))
                 {
                     Cursor = Cursors.SizeNESW;                  //Bottom Left
                 }
@@ -849,13 +924,13 @@ namespace ReaLTaiizor.Controls
                     Cursor = Cursors.SizeWE;                    //Left
                 }
             }
-            else if (e.Location.Y > this.Height - BORDER_WIDTH)
+            else if (e.Location.Y > this.Height - (int)(BORDER_WIDTH * ScaleFactor))
             {
                 Cursor = Cursors.SizeNS;                        //Bottom
             }
             else
             {
-                if (e.Location.Y < _drawerItemRects[_drawerItemRects.Count - 1].Bottom && (e.Location.X + this.Location.X) >= BORDER_WIDTH)
+                if (e.Location.Y < _drawerItemRects[_drawerItemRects.Count - 1].Bottom && (e.Location.X + this.Location.X) >= (int)(BORDER_WIDTH * ScaleFactor))
                 {
                     Cursor = Cursors.Hand;
                 }
@@ -924,7 +999,7 @@ namespace ReaLTaiizor.Controls
             {
                 _drawerItemRects[i] = new Rectangle(
                     (int)(SkinManager.FORM_PADDING * 0.75) - (ShowIconsWhenHidden ? Location.X : 0),
-                    (TAB_HEADER_PADDING * 2 * i) + (int)(SkinManager.FORM_PADDING >> 1),
+                    ((int)(TAB_HEADER_PADDING * ScaleFactor) * 2 * i) + (int)(SkinManager.FORM_PADDING >> 1),
                     Width + (ShowIconsWhenHidden ? Location.X : 0) - (int)(SkinManager.FORM_PADDING * 1.5) - 1,
                     drawerItemHeight);
 

--- a/src/ReaLTaiizor/Controls/Drawer/MaterialDrawer.cs
+++ b/src/ReaLTaiizor/Controls/Drawer/MaterialDrawer.cs
@@ -403,10 +403,14 @@ namespace ReaLTaiizor.Controls
 
                 // add to dictionary
                 string ik = string.Concat(tabPage.ImageKey, "_", tabPage.Name);
-                TextureBrush tBrush = new TextureBrush(bgray);
-                tBrush.WrapMode = WrapMode.Clamp;
-                TextureBrush tBrushColor = new TextureBrush(bcolor);
-                tBrushColor.WrapMode = WrapMode.Clamp;
+                TextureBrush tBrush = new(bgray)
+                {
+                    WrapMode = WrapMode.Clamp
+                };
+                TextureBrush tBrushColor = new(bcolor)
+                {
+                    WrapMode = WrapMode.Clamp
+                };
                 // calc center positions.
                 float x = _drawerItemRects[currentTabIndex].X + (drawerItemHeight / 2.0f) - (sW / 2.0f);
                 float y = _drawerItemRects[currentTabIndex].Y + (drawerItemHeight / 2.0f) - (sH / 2.0f);
@@ -454,10 +458,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -470,10 +472,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public MaterialDrawer()

--- a/src/ReaLTaiizor/Controls/Drawer/MaterialDrawer.cs
+++ b/src/ReaLTaiizor/Controls/Drawer/MaterialDrawer.cs
@@ -358,7 +358,7 @@ namespace ReaLTaiizor.Controls
                         originalImg.Height,
                         GraphicsUnit.Pixel,
                         grayImageAttributes
-                        );  
+                        );
                 }
 
                 // Create a pre-processed copy of the image (PRIMARY COLOR)
@@ -366,7 +366,7 @@ namespace ReaLTaiizor.Controls
                 using (Graphics gColor = Graphics.FromImage(bcolor))
                 {
                     gColor.InterpolationMode = InterpolationMode.HighQualityBicubic;
-                    gColor.Clear(Color.Transparent); 
+                    gColor.Clear(Color.Transparent);
 
                     Rectangle destRectScaled = new(0, 0, sW, sH);
 
@@ -378,7 +378,7 @@ namespace ReaLTaiizor.Controls
                         originalImg.Height,
                         GraphicsUnit.Pixel,
                         colorImageAttributes
-                        ); 
+                        );
                 }
 
                 // added processed image to brush for drawing

--- a/src/ReaLTaiizor/Controls/Drawer/MaterialDrawer.cs
+++ b/src/ReaLTaiizor/Controls/Drawer/MaterialDrawer.cs
@@ -613,8 +613,8 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs e)
         {
-            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            // ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            // ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
             Paint(e);
         }
 

--- a/src/ReaLTaiizor/Controls/Label/MaterialLabel.cs
+++ b/src/ReaLTaiizor/Controls/Label/MaterialLabel.cs
@@ -141,8 +141,8 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs e)
         {
-            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            // ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            // ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
 
             Graphics g = e.Graphics;
             g.Clear(Parent.BackColor == Color.Transparent ? ((Parent.Parent == null || (Parent.Parent != null && Parent.Parent.BackColor == Color.Transparent)) ? SkinManager.BackgroundColor : Parent.Parent.BackColor) : Parent.BackColor);

--- a/src/ReaLTaiizor/Controls/Label/MaterialLabel.cs
+++ b/src/ReaLTaiizor/Controls/Label/MaterialLabel.cs
@@ -55,7 +55,7 @@ namespace ReaLTaiizor.Controls
             set
             {
                 field = value;
-                Font = SkinManager.GetFontByType(field);
+                Font = SkinManager.GetFontByType(field, ScaleFactor);
                 Refresh();
             }
         } = MaterialSkinManager.FontType.Body1;
@@ -68,12 +68,14 @@ namespace ReaLTaiizor.Controls
 
         public override Size GetPreferredSize(Size proposedSize)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
             if (AutoSize)
             {
                 Size strSize;
                 using (MaterialNativeTextRenderer NativeText = new(CreateGraphics()))
                 {
-                    strSize = NativeText.MeasureLogString(Text, SkinManager.GetLogFontByType(FontType));
+                    strSize = NativeText.MeasureLogString(Text, SkinManager.GetLogFontByType(FontType, ScaleFactor));
                     strSize.Width += 1; // necessary to avoid a bug when autosize = true
                 }
                 return strSize;
@@ -85,6 +87,40 @@ namespace ReaLTaiizor.Controls
         }
 
         private MaterialNativeTextRenderer.TextAlignFlags Alignment;
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
 
         private void updateAligment()
         {
@@ -105,6 +141,9 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             Graphics g = e.Graphics;
             g.Clear(Parent.BackColor == Color.Transparent ? ((Parent.Parent == null || (Parent.Parent != null && Parent.Parent.BackColor == Color.Transparent)) ? SkinManager.BackgroundColor : Parent.Parent.BackColor) : Parent.BackColor);
 
@@ -112,7 +151,7 @@ namespace ReaLTaiizor.Controls
             using MaterialNativeTextRenderer NativeText = new(g);
             NativeText.DrawMultilineTransparentText(
                 Text,
-                SkinManager.GetLogFontByType(FontType),
+                SkinManager.GetLogFontByType(FontType, ScaleFactor),
                 Enabled ? HighEmphasis ? UseAccent ?
                 SkinManager.ColorScheme.AccentColor : // High emphasis, accent
                 (SkinManager.Theme == MaterialSkinManager.Themes.LIGHT) ?
@@ -127,7 +166,9 @@ namespace ReaLTaiizor.Controls
 
         protected override void InitLayout()
         {
-            Font = SkinManager.GetFontByType(FontType);
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            Font = SkinManager.GetFontByType(FontType, ScaleFactor);
         }
     }
 

--- a/src/ReaLTaiizor/Controls/Label/MaterialLabel.cs
+++ b/src/ReaLTaiizor/Controls/Label/MaterialLabel.cs
@@ -100,10 +100,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -116,10 +114,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         private void updateAligment()

--- a/src/ReaLTaiizor/Controls/ListBox/MaterialListBox.cs
+++ b/src/ReaLTaiizor/Controls/ListBox/MaterialListBox.cs
@@ -41,9 +41,51 @@ namespace ReaLTaiizor.Controls
         private Font _secondaryFont;
 
         private const int _leftrightPadding = 16;
-        private int _primaryTextBottomPadding = 0;
-        private int _secondaryTextTopPadding = 0;
-        private int _secondaryTextBottomPadding = 0;
+        private int _primaryTextBottomPadding = 0; // No need to modify as DPI changes
+        private int _secondaryTextTopPadding = 0; // No need to modify as DPI changes
+        private int _secondaryTextBottomPadding = 0; // No need to modify as DPI changes
+
+        private const int SCROLL_BAR_WIDTH = 12;
+        // Vertical paddings (logical pixels)
+        private const int ITEM_PADDING_TOP = 8;
+        private const int ITEM_PADDING_BOTTOM = 8;
+
+        private const int TEXT_LINE_SPACING = 4;
+        private const int DENSE_REDUCTION = 4;
+        // DO NOT USE MAGIC NUMBERS OR THE SCALING WILL MISFUNCTION - by HYrecv
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
 
         public enum ListBoxStyle
         {
@@ -260,8 +302,8 @@ namespace ReaLTaiizor.Controls
             );
             UpdateStyles();
             base.BackColor = Color.Transparent;
-            base.Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1);
-            _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1);
+            base.Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
+            _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
             SetDefaults();
             ShowBorder = true;
             ShowScrollBar = false;
@@ -284,7 +326,7 @@ namespace ReaLTaiizor.Controls
             _scrollBar = new MaterialScrollBar()
             {
                 Orientation = MateScrollOrientation.Vertical,
-                Size = new Size(12, Height),
+                Size = new Size((int)(SCROLL_BAR_WIDTH * ScaleFactor), Height),
                 Maximum = Items.Count * _itemHeight,
                 SmallChange = _itemHeight,
                 LargeChange = _itemHeight
@@ -310,7 +352,93 @@ namespace ReaLTaiizor.Controls
             Invalidate();
         }
 
-        private void UpdateItemSpecs()
+        private static int GetFontHeight(Font font)
+        {
+            return font.Height;
+        }
+
+
+        private void UpdateItemSpecs() 
+            // Due to abuse to magic nums, original code here is replaced by GPT-5.2 generated ones.
+            // If it isn't working as expected, then I also have no idea 'bout who caused this ;D
+        {
+            bool isDense = Density == MaterialItemDensity.Dense;
+
+            // 1️⃣ Select font（Content，not layout）
+            switch (Style)
+            {
+                case ListBoxStyle.TwoLine:
+                    _primaryFont = isDense
+                        ? SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor)
+                        : SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
+
+                    _secondaryFont = isDense
+                        ? SkinManager.GetFontByType(MaterialSkinManager.FontType.Body2, ScaleFactor)
+                        : SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
+                    break;
+
+                case ListBoxStyle.ThreeLine:
+                    _primaryFont = isDense
+                        ? SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor)
+                        : SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
+
+                    _secondaryFont = isDense
+                        ? SkinManager.GetFontByType(MaterialSkinManager.FontType.Body2, ScaleFactor)
+                        : SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
+                    break;
+
+                default: // SingleLine
+                    _primaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
+                    _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
+                    break;
+            }
+
+            // 2️⃣ Calc text height
+            int primaryTextHeight = GetFontHeight(_primaryFont);
+            int secondaryTextHeight = GetFontHeight(_secondaryFont);
+
+            // 3️⃣ Set padding（instead of magic）
+            _primaryTextBottomPadding = (int)(TEXT_LINE_SPACING * ScaleFactor);
+            _secondaryTextTopPadding = (int)(TEXT_LINE_SPACING * ScaleFactor);
+            _secondaryTextBottomPadding = (int)(TEXT_LINE_SPACING * ScaleFactor);
+
+            int verticalPadding =
+                (int)(ITEM_PADDING_TOP * ScaleFactor) +
+                (int)(ITEM_PADDING_BOTTOM * ScaleFactor) -
+                (isDense ? (int)(DENSE_REDUCTION * ScaleFactor) : 0);
+
+            // 4️⃣ Set height from Style 
+            switch (Style)
+            {
+                case ListBoxStyle.TwoLine:
+                    _itemHeight =
+                        primaryTextHeight +
+                        secondaryTextHeight +
+                        (int)(TEXT_LINE_SPACING * ScaleFactor) +
+                        verticalPadding;
+                    break;
+
+                case ListBoxStyle.ThreeLine:
+                    _itemHeight =
+                        primaryTextHeight +
+                        secondaryTextHeight * 2 +
+                        (int)(TEXT_LINE_SPACING * ScaleFactor) * 2 +
+                        verticalPadding;
+                    break;
+
+                default: // SingleLine
+                    _itemHeight =
+                        primaryTextHeight +
+                        verticalPadding;
+                    break;
+            }
+        }
+
+        [Obsolete(
+    "Aborted legacy layout logic based on magic numbers. " +
+    "Replaced by font-height–driven layout to support DPI and multi-language scenarios.",
+    error: false)]
+        private void UpdateItemSpecsAborted()
         {
             if (Style == ListBoxStyle.TwoLine)
             {
@@ -321,16 +449,16 @@ namespace ReaLTaiizor.Controls
                     _itemHeight = 60;
                     _primaryTextBottomPadding = 2;
                     _secondaryTextBottomPadding = 10;
-                    _primaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1);
-                    _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body2);
+                    _primaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
+                    _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body2, ScaleFactor);
                 }
                 else
                 {
                     _itemHeight = 72;
                     _primaryTextBottomPadding = 4;
                     _secondaryTextBottomPadding = 16;
-                    _primaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1);
-                    _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1);
+                    _primaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
+                    _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
                 }
             }
             else if (Style == ListBoxStyle.ThreeLine)
@@ -342,15 +470,15 @@ namespace ReaLTaiizor.Controls
                 {
                     _itemHeight = 76;
                     _secondaryTextBottomPadding = 16;
-                    _primaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1);
-                    _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body2);
+                    _primaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
+                    _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body2, ScaleFactor);
                 }
                 else
                 {
                     _itemHeight = 88;
                     _secondaryTextBottomPadding = 12;
-                    _primaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1);
-                    _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1);
+                    _primaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
+                    _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
                 }
             }
             else
@@ -365,8 +493,8 @@ namespace ReaLTaiizor.Controls
                     _itemHeight = 48;
                 }
 
-                _primaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1);
-                _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1);
+                _primaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
+                _secondaryFont = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
             }
 
         }
@@ -381,6 +509,9 @@ namespace ReaLTaiizor.Controls
             {
                 return;
             }
+
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
 
             Graphics g = e.Graphics;
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
@@ -455,7 +586,7 @@ namespace ReaLTaiizor.Controls
                 }
 
                 //Define primary & secondary Text Rect
-                Rectangle primaryTextRect = new(itemRect.X + _leftrightPadding, itemRect.Y, itemRect.Width - (2 * _leftrightPadding), itemRect.Height);
+                Rectangle primaryTextRect = new(itemRect.X + (int)(_leftrightPadding * ScaleFactor), itemRect.Y, itemRect.Width - (2 * (int)(_leftrightPadding * ScaleFactor)), itemRect.Height);
                 Rectangle secondaryTextRect = new();
 
                 if (Style == ListBoxStyle.TwoLine)
@@ -696,8 +827,19 @@ namespace ReaLTaiizor.Controls
 
         #endregion Events
 
+        protected override void OnDpiChangedAfterParent(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
+            base.OnDpiChangedAfterParent(e);
+        }
+
         protected override void OnSizeChanged(EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             InvalidateScroll(this, e);
             InvalidateLayout();
 
@@ -786,7 +928,7 @@ namespace ReaLTaiizor.Controls
 
         private void InvalidateLayout()
         {
-            _scrollBar.Size = new Size(12, Height - (ShowBorder ? 2 : 0));
+            _scrollBar.Size = new Size((int)(SCROLL_BAR_WIDTH * ScaleFactor), Height - (ShowBorder ? 2 : 0));
             _scrollBar.Location = new Point(Width - (_scrollBar.Width + (ShowBorder ? 1 : 0)), ShowBorder ? 1 : 0);
 
             Invalidate();
@@ -897,7 +1039,7 @@ namespace ReaLTaiizor.Controls
         {
             base.OnHandleCreated(e);
 
-            _scrollBar.Size = new Size(12, Height - (ShowBorder ? 2 : 0));
+            _scrollBar.Size = new Size((int)(SCROLL_BAR_WIDTH * ScaleFactor), Height - (ShowBorder ? 2 : 0));
             _scrollBar.Location = new Point(Width - (_scrollBar.Width + (ShowBorder ? 1 : 0)), ShowBorder ? 1 : 0);
 
             InvalidateScroll(this, e);

--- a/src/ReaLTaiizor/Controls/ListBox/MaterialListBox.cs
+++ b/src/ReaLTaiizor/Controls/ListBox/MaterialListBox.cs
@@ -512,8 +512,8 @@ namespace ReaLTaiizor.Controls
                 return;
             }
 
-            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            // ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            // ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
 
             Graphics g = e.Graphics;
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;

--- a/src/ReaLTaiizor/Controls/ListBox/MaterialListBox.cs
+++ b/src/ReaLTaiizor/Controls/ListBox/MaterialListBox.cs
@@ -67,10 +67,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -83,10 +81,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public enum ListBoxStyle

--- a/src/ReaLTaiizor/Controls/ListBox/MaterialListBox.cs
+++ b/src/ReaLTaiizor/Controls/ListBox/MaterialListBox.cs
@@ -49,6 +49,8 @@ namespace ReaLTaiizor.Controls
         // Vertical paddings (logical pixels)
         private const int ITEM_PADDING_TOP = 8;
         private const int ITEM_PADDING_BOTTOM = 8;
+        private const int THREE_LINE_PRIMARY_DEFAULT_HEIGHT = 36;
+        private const int THREE_LINE_PRIMARY_HEIGHT = 30;
 
         private const int TEXT_LINE_SPACING = 4;
         private const int DENSE_REDUCTION = 4;
@@ -597,11 +599,11 @@ namespace ReaLTaiizor.Controls
                 {
                     if (Density == MaterialItemDensity.Default)
                     {
-                        primaryTextRect.Height = 36 - _primaryTextBottomPadding;
+                        primaryTextRect.Height = (int)(THREE_LINE_PRIMARY_DEFAULT_HEIGHT * ScaleFactor) - _primaryTextBottomPadding;
                     }
                     else
                     {
-                        primaryTextRect.Height = 30 - _primaryTextBottomPadding;
+                        primaryTextRect.Height = (int)(THREE_LINE_PRIMARY_HEIGHT * ScaleFactor) - _primaryTextBottomPadding;
                     }
                 }
                 secondaryTextRect = new Rectangle(primaryTextRect.X, primaryTextRect.Y + primaryTextRect.Height + _primaryTextBottomPadding + _secondaryTextTopPadding, primaryTextRect.Width, _itemHeight - _secondaryTextBottomPadding - primaryTextRect.Height - (_primaryTextBottomPadding + _secondaryTextTopPadding));

--- a/src/ReaLTaiizor/Controls/ListBox/MaterialListBox.cs
+++ b/src/ReaLTaiizor/Controls/ListBox/MaterialListBox.cs
@@ -360,9 +360,9 @@ namespace ReaLTaiizor.Controls
         }
 
 
-        private void UpdateItemSpecs() 
-            // Due to abuse to magic nums, original code here is replaced by GPT-5.2 generated ones.
-            // If it isn't working as expected, then I also have no idea 'bout who caused this ;D
+        private void UpdateItemSpecs()
+        // Due to abuse to magic nums, original code here is replaced by GPT-5.2 generated ones.
+        // If it isn't working as expected, then I also have no idea 'bout who caused this ;D
         {
             bool isDense = Density == MaterialItemDensity.Dense;
 
@@ -410,30 +410,20 @@ namespace ReaLTaiizor.Controls
                 (isDense ? (int)(DENSE_REDUCTION * ScaleFactor) : 0);
 
             // 4️⃣ Set height from Style 
-            switch (Style)
+            _itemHeight = Style switch
             {
-                case ListBoxStyle.TwoLine:
-                    _itemHeight =
-                        primaryTextHeight +
-                        secondaryTextHeight +
-                        (int)(TEXT_LINE_SPACING * ScaleFactor) +
-                        verticalPadding;
-                    break;
-
-                case ListBoxStyle.ThreeLine:
-                    _itemHeight =
-                        primaryTextHeight +
-                        secondaryTextHeight * 2 +
-                        (int)(TEXT_LINE_SPACING * ScaleFactor) * 2 +
-                        verticalPadding;
-                    break;
-
-                default: // SingleLine
-                    _itemHeight =
-                        primaryTextHeight +
-                        verticalPadding;
-                    break;
-            }
+                ListBoxStyle.TwoLine => primaryTextHeight +
+                                        secondaryTextHeight +
+                                        (int)(TEXT_LINE_SPACING * ScaleFactor) +
+                                        verticalPadding,
+                ListBoxStyle.ThreeLine => primaryTextHeight +
+                                        (secondaryTextHeight * 2) +
+                                        ((int)(TEXT_LINE_SPACING * ScaleFactor) * 2) +
+                                        verticalPadding,
+                // SingleLine
+                _ => primaryTextHeight +
+                                        verticalPadding,
+            };
         }
 
         [Obsolete(

--- a/src/ReaLTaiizor/Controls/ListView/MaterialListView.cs
+++ b/src/ReaLTaiizor/Controls/ListView/MaterialListView.cs
@@ -58,10 +58,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -74,10 +72,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public MaterialListView()

--- a/src/ReaLTaiizor/Controls/ListView/MaterialListView.cs
+++ b/src/ReaLTaiizor/Controls/ListView/MaterialListView.cs
@@ -46,6 +46,40 @@ namespace ReaLTaiizor.Controls
         private const int PAD = 16;
         private const int ITEMS_HEIGHT = 52;
 
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         public MaterialListView()
         {
             GridLines = false;
@@ -105,10 +139,10 @@ namespace ReaLTaiizor.Controls
             using MaterialNativeTextRenderer NativeText = new(g);
             NativeText.DrawTransparentText(
                 e.Header.Text,
-                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2),
+                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2, ScaleFactor),
                 Enabled ? SkinManager.TextHighEmphasisNoAlphaColor : SkinManager.TextDisabledOrHintColor,
-                new Point(e.Bounds.Location.X + PAD, e.Bounds.Location.Y),
-                new Size(e.Bounds.Size.Width - (PAD * 2), e.Bounds.Size.Height),
+                new Point(e.Bounds.Location.X + (int)(PAD * ScaleFactor), e.Bounds.Location.Y),
+                new Size(e.Bounds.Size.Width - ((int)(PAD * ScaleFactor) * 2), e.Bounds.Size.Height),
                 e.Header.TextAlign == HorizontalAlignment.Left ? MaterialNativeTextRenderer.TextAlignFlags.Left | MaterialNativeTextRenderer.TextAlignFlags.Middle
                 : e.Header.TextAlign == HorizontalAlignment.Right ? MaterialNativeTextRenderer.TextAlignFlags.Right | MaterialNativeTextRenderer.TextAlignFlags.Middle
                 : MaterialNativeTextRenderer.TextAlignFlags.Center | MaterialNativeTextRenderer.TextAlignFlags.Middle);
@@ -144,10 +178,10 @@ namespace ReaLTaiizor.Controls
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                     subItem.Text,
-                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body2),
+                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body2, ScaleFactor),
                     Enabled ? SkinManager.TextHighEmphasisNoAlphaColor : SkinManager.TextDisabledOrHintColor,
-                    new Point(subItem.Bounds.X + PAD, subItem.Bounds.Y),
-                    new Size(subItem.Bounds.Width - (PAD * 2), subItem.Bounds.Height),
+                    new Point(subItem.Bounds.X + (int)(PAD * ScaleFactor), subItem.Bounds.Y),
+                    new Size(subItem.Bounds.Width - ((int)(PAD * ScaleFactor) * 2), subItem.Bounds.Height),
                     Columns[id].TextAlign == HorizontalAlignment.Left
                             ? MaterialNativeTextRenderer.TextAlignFlags.Left | MaterialNativeTextRenderer.TextAlignFlags.Middle
                             : Columns[id].TextAlign == HorizontalAlignment.Right
@@ -160,18 +194,27 @@ namespace ReaLTaiizor.Controls
         // Resize
         protected override void OnColumnWidthChanging(ColumnWidthChangingEventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnColumnWidthChanging(e);
             AutoResize();
         }
 
         protected override void OnColumnWidthChanged(ColumnWidthChangedEventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnColumnWidthChanged(e);
             AutoResize();
         }
 
         protected override void OnResize(EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnResize(e);
             AutoResize();
         }
@@ -205,8 +248,18 @@ namespace ReaLTaiizor.Controls
             Size = new Size(w, h);
         }
 
+        protected override void OnDpiChangedAfterParent(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            base.OnDpiChangedAfterParent(e);
+        }
+
         protected override void InitLayout()
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.InitLayout();
 
             // enforce settings

--- a/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
+++ b/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
@@ -625,7 +625,7 @@ namespace ReaLTaiizor.Controls
                 if (Collapse)
                 {
                     //Draw Expand button
-                    System.Drawing.Drawing2D.GraphicsPath pth = new();
+                    GraphicsPath pth = new();
                     PointF TopLeft = new(_expandcollapseBounds.X + (6 * ScaleFactor), _expandcollapseBounds.Y + (9 * ScaleFactor));
                     PointF MidBottom = new(_expandcollapseBounds.X + (12 * ScaleFactor), _expandcollapseBounds.Y + (15 * ScaleFactor));
                     PointF TopRight = new(_expandcollapseBounds.X + (18 * ScaleFactor), _expandcollapseBounds.Y + (9 * ScaleFactor));
@@ -637,7 +637,7 @@ namespace ReaLTaiizor.Controls
                 else
                 {
                     // Draw Collapse button
-                    System.Drawing.Drawing2D.GraphicsPath pth = new();
+                    GraphicsPath pth = new();
                     PointF BottomLeft = new(_expandcollapseBounds.X + (6 * ScaleFactor), _expandcollapseBounds.Y + (15 * ScaleFactor));
                     PointF MidTop = new(_expandcollapseBounds.X + (12 * ScaleFactor), _expandcollapseBounds.Y + (9 * ScaleFactor));
                     PointF BottomRight = new(_expandcollapseBounds.X + (18 * ScaleFactor), _expandcollapseBounds.Y + (15 * ScaleFactor));

--- a/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
+++ b/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
@@ -625,7 +625,7 @@ namespace ReaLTaiizor.Controls
                 if (Collapse)
                 {
                     //Draw Expand button
-                    GraphicsPath pth = new();
+                    using GraphicsPath pth = new();
                     PointF TopLeft = new(_expandcollapseBounds.X + (6 * ScaleFactor), _expandcollapseBounds.Y + (9 * ScaleFactor));
                     PointF MidBottom = new(_expandcollapseBounds.X + (12 * ScaleFactor), _expandcollapseBounds.Y + (15 * ScaleFactor));
                     PointF TopRight = new(_expandcollapseBounds.X + (18 * ScaleFactor), _expandcollapseBounds.Y + (9 * ScaleFactor));
@@ -637,7 +637,7 @@ namespace ReaLTaiizor.Controls
                 else
                 {
                     // Draw Collapse button
-                    GraphicsPath pth = new();
+                    using GraphicsPath pth = new();
                     PointF BottomLeft = new(_expandcollapseBounds.X + (6 * ScaleFactor), _expandcollapseBounds.Y + (15 * ScaleFactor));
                     PointF MidTop = new(_expandcollapseBounds.X + (12 * ScaleFactor), _expandcollapseBounds.Y + (9 * ScaleFactor));
                     PointF BottomRight = new(_expandcollapseBounds.X + (18 * ScaleFactor), _expandcollapseBounds.Y + (15 * ScaleFactor));

--- a/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
+++ b/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
@@ -654,7 +654,10 @@ namespace ReaLTaiizor.Controls
             if (!Collapse && ShowValidationButtons)
             {
                 //Draw divider
-                g.DrawLine(new Pen(SkinManager.DividersColor, 1), new Point(0, Height - (int)(_footerHeight * ScaleFactor)), new Point(Width, Height - (int)(_footerHeight * ScaleFactor)));
+                using (var dividerPen = new Pen(SkinManager.DividersColor, 1))
+                {
+                    g.DrawLine(dividerPen, new Point(0, Height - (int)(_footerHeight * ScaleFactor)), new Point(Width, Height - (int)(_footerHeight * ScaleFactor)));
+                }
             }
         }
 

--- a/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
+++ b/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
@@ -630,9 +630,9 @@ namespace ReaLTaiizor.Controls
                 {
                     //Draw Expand button
                     System.Drawing.Drawing2D.GraphicsPath pth = new();
-                    PointF TopLeft = new(_expandcollapseBounds.X + 6 * ScaleFactor, _expandcollapseBounds.Y + 9 * ScaleFactor);
-                    PointF MidBottom = new(_expandcollapseBounds.X + 12 * ScaleFactor, _expandcollapseBounds.Y + 15 * ScaleFactor);
-                    PointF TopRight = new(_expandcollapseBounds.X + 18 * ScaleFactor, _expandcollapseBounds.Y + 9 * ScaleFactor);
+                    PointF TopLeft = new(_expandcollapseBounds.X + (6 * ScaleFactor), _expandcollapseBounds.Y + (9 * ScaleFactor));
+                    PointF MidBottom = new(_expandcollapseBounds.X + (12 * ScaleFactor), _expandcollapseBounds.Y + (15 * ScaleFactor));
+                    PointF TopRight = new(_expandcollapseBounds.X + (18 * ScaleFactor), _expandcollapseBounds.Y + (9 * ScaleFactor));
                     pth.AddLine(TopLeft, MidBottom);
                     pth.AddLine(TopRight, MidBottom);
                     g.DrawPath(formButtonsPen, pth);
@@ -642,9 +642,9 @@ namespace ReaLTaiizor.Controls
                 {
                     // Draw Collapse button
                     System.Drawing.Drawing2D.GraphicsPath pth = new();
-                    PointF BottomLeft = new(_expandcollapseBounds.X + 6 * ScaleFactor, _expandcollapseBounds.Y + 15 * ScaleFactor);
-                    PointF MidTop = new(_expandcollapseBounds.X + 12 * ScaleFactor, _expandcollapseBounds.Y + 9 * ScaleFactor);
-                    PointF BottomRight = new(_expandcollapseBounds.X + 18 * ScaleFactor, _expandcollapseBounds.Y + 15 * ScaleFactor);
+                    PointF BottomLeft = new(_expandcollapseBounds.X + (6 * ScaleFactor), _expandcollapseBounds.Y + (15 * ScaleFactor));
+                    PointF MidTop = new(_expandcollapseBounds.X + (12 * ScaleFactor), _expandcollapseBounds.Y + (9 * ScaleFactor));
+                    PointF BottomRight = new(_expandcollapseBounds.X + (18 * ScaleFactor), _expandcollapseBounds.Y + (15 * ScaleFactor));
                     pth.AddLine(BottomLeft, MidTop);
                     pth.AddLine(BottomRight, MidTop);
                     g.DrawPath(formButtonsPen, pth);
@@ -654,7 +654,7 @@ namespace ReaLTaiizor.Controls
             if (!Collapse && ShowValidationButtons)
             {
                 //Draw divider
-                using (var dividerPen = new Pen(SkinManager.DividersColor, 1))
+                using (Pen dividerPen = new Pen(SkinManager.DividersColor, 1))
                 {
                     g.DrawLine(dividerPen, new Point(0, Height - (int)(_footerHeight * ScaleFactor)), new Point(Width, Height - (int)(_footerHeight * ScaleFactor)));
                 }

--- a/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
+++ b/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
@@ -54,10 +54,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -70,10 +68,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         private enum ButtonState
@@ -654,10 +650,8 @@ namespace ReaLTaiizor.Controls
             if (!Collapse && ShowValidationButtons)
             {
                 //Draw divider
-                using (Pen dividerPen = new Pen(SkinManager.DividersColor, 1))
-                {
-                    g.DrawLine(dividerPen, new Point(0, Height - (int)(_footerHeight * ScaleFactor)), new Point(Width, Height - (int)(_footerHeight * ScaleFactor)));
-                }
+                using Pen dividerPen = new(SkinManager.DividersColor, 1);
+                g.DrawLine(dividerPen, new Point(0, Height - (int)(_footerHeight * ScaleFactor)), new Point(Width, Height - (int)(_footerHeight * ScaleFactor)));
             }
         }
 

--- a/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
+++ b/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
@@ -41,6 +41,41 @@ namespace ReaLTaiizor.Controls
         private Rectangle _savebuttonBounds;
         private Rectangle _cancelbuttonBounds;
 
+        private bool _needsLayoutRefresh = false;
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         private enum ButtonState
         {
             SaveOver,
@@ -127,7 +162,7 @@ namespace ReaLTaiizor.Controls
         public int ExpandHeight
         {
             get => _expandHeight;
-            set { if (value < _minHeight) { value = _minHeight; } _expandHeight = value; Invalidate(); }
+            set { if (value < (int)(_minHeight * ScaleFactor)) { value = (int)(_minHeight * ScaleFactor); } _expandHeight = value; Invalidate(); }
         }
 
         [DefaultValue(true)]
@@ -272,18 +307,27 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnCreateControl()
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnCreateControl();
-            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1);
+            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
         }
 
         protected override void InitLayout()
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             LocationChanged += (sender, e) => { Parent?.Invalidate(); };
             ForeColor = SkinManager.TextHighEmphasisColor;
         }
 
         protected override void OnParentChanged(EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnParentChanged(e);
             if (Parent != null)
             {
@@ -369,28 +413,39 @@ namespace ReaLTaiizor.Controls
             BackColor = SkinManager.BackgroundColor;
         }
 
+        protected override void OnDpiChangedAfterParent(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
+            base.OnDpiChangedAfterParent(e);
+        }
+
         protected override void OnResize(EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             if (!Collapse)
             {
                 if (DesignMode)
                 {
-                    _expandHeight = Height;
+                    _expandHeight = (int)(Height / ScaleFactor);
                 }
-                if (Height < _minHeight)
+                if (Height < (int)(_minHeight * ScaleFactor))
                 {
-                    Height = _minHeight;
+                    Height = (int)(_minHeight * ScaleFactor);
                 }
             }
             else
             {
-                Height = _headerHeightCollapse;
+                Height = (int)(_headerHeightCollapse * ScaleFactor);
             }
 
             base.OnResize(e);
 
-            _headerBounds = new Rectangle(ClientRectangle.X, ClientRectangle.Y, ClientRectangle.Width, _headerHeight);
-            _expandcollapseBounds = new Rectangle(Width - _leftrightPadding - _expandcollapsbuttonsize, (int)((_headerHeight - _expandcollapsbuttonsize) / 2), _expandcollapsbuttonsize, _expandcollapsbuttonsize);
+            _headerBounds = new Rectangle(ClientRectangle.X, ClientRectangle.Y, ClientRectangle.Width, (int)(_headerHeight * ScaleFactor));
+            _expandcollapseBounds = new Rectangle(Width - (int)(_leftrightPadding * ScaleFactor) - (int)(_expandcollapsbuttonsize * ScaleFactor), (int)(((int)(_headerHeight * ScaleFactor) - (int)(_expandcollapsbuttonsize * ScaleFactor)) / 2), (int)(_expandcollapsbuttonsize * ScaleFactor), (int)(_expandcollapsbuttonsize * ScaleFactor));
 
             UpdateRects();
 
@@ -473,9 +528,20 @@ namespace ReaLTaiizor.Controls
             Invalidate();
         }
 
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            _needsLayoutRefresh = true;
+        }
 
         protected override void OnPaint(PaintEventArgs e)
         {
+            if (_needsLayoutRefresh)
+            {
+                UpdateRects();
+                _needsLayoutRefresh = false;
+            }
+
             Graphics g = e.Graphics;
             g.TextRenderingHint = TextRenderingHint.AntiAlias;
 
@@ -518,10 +584,10 @@ namespace ReaLTaiizor.Controls
 
             // Calc text Rect
             Rectangle headerRect = new(
-                _leftrightPadding,
-                (_headerHeight - _textHeaderHeight) / 2,
-                TextRenderer.MeasureText(Title, Font).Width + _expansionPanelDefaultPadding,
-                _textHeaderHeight);
+                (int)(_leftrightPadding * ScaleFactor),
+                ((int)(_headerHeight * ScaleFactor) - (int)(_textHeaderHeight * ScaleFactor)) / 2,
+                TextRenderer.MeasureText(Title, SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor)).Width + (int)(_expansionPanelDefaultPadding * ScaleFactor),
+                (int)(_textHeaderHeight * ScaleFactor));
 
             //Draw  headers
             using (MaterialNativeTextRenderer NativeText = new(g))
@@ -529,7 +595,7 @@ namespace ReaLTaiizor.Controls
                 // Draw header text
                 NativeText.DrawTransparentText(
                     Title,
-                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1),
+                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor),
                     Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                     headerRect.Location,
                     headerRect.Size,
@@ -541,16 +607,16 @@ namespace ReaLTaiizor.Controls
                 //Draw description header text 
 
                 Rectangle headerDescriptionRect = new(
-                    headerRect.Right + _expansionPanelDefaultPadding,
-                    (_headerHeight - _textHeaderHeight) / 2,
-                    _expandcollapseBounds.Left - (headerRect.Right + _expansionPanelDefaultPadding) - _expansionPanelDefaultPadding,
-                    _textHeaderHeight);
+                    headerRect.Right + (int)(_expansionPanelDefaultPadding * ScaleFactor),
+                    ((int)(_headerHeight * ScaleFactor) - (int)(_textHeaderHeight * ScaleFactor)) / 2,
+                    _expandcollapseBounds.Left - (headerRect.Right + (int)(_expansionPanelDefaultPadding * ScaleFactor)) - (int)(_expansionPanelDefaultPadding * ScaleFactor),
+                    (int)(_textHeaderHeight * ScaleFactor));
 
                 using MaterialNativeTextRenderer NativeText = new(g);
                 // Draw description header text 
                 NativeText.DrawTransparentText(
                 Description,
-                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1),
+                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor),
                  SkinManager.TextDisabledOrHintColor,
                 headerDescriptionRect.Location,
                 headerDescriptionRect.Size,
@@ -564,20 +630,21 @@ namespace ReaLTaiizor.Controls
                 {
                     //Draw Expand button
                     System.Drawing.Drawing2D.GraphicsPath pth = new();
-                    PointF TopLeft = new(_expandcollapseBounds.X + 6, _expandcollapseBounds.Y + 9);
-                    PointF MidBottom = new(_expandcollapseBounds.X + 12, _expandcollapseBounds.Y + 15);
-                    PointF TopRight = new(_expandcollapseBounds.X + 18, _expandcollapseBounds.Y + 9);
+                    PointF TopLeft = new(_expandcollapseBounds.X + 6 * ScaleFactor, _expandcollapseBounds.Y + 9 * ScaleFactor);
+                    PointF MidBottom = new(_expandcollapseBounds.X + 12 * ScaleFactor, _expandcollapseBounds.Y + 15 * ScaleFactor);
+                    PointF TopRight = new(_expandcollapseBounds.X + 18 * ScaleFactor, _expandcollapseBounds.Y + 9 * ScaleFactor);
                     pth.AddLine(TopLeft, MidBottom);
                     pth.AddLine(TopRight, MidBottom);
                     g.DrawPath(formButtonsPen, pth);
+#warning Magic Numbers
                 }
                 else
                 {
                     // Draw Collapse button
                     System.Drawing.Drawing2D.GraphicsPath pth = new();
-                    PointF BottomLeft = new(_expandcollapseBounds.X + 6, _expandcollapseBounds.Y + 15);
-                    PointF MidTop = new(_expandcollapseBounds.X + 12, _expandcollapseBounds.Y + 9);
-                    PointF BottomRight = new(_expandcollapseBounds.X + 18, _expandcollapseBounds.Y + 15);
+                    PointF BottomLeft = new(_expandcollapseBounds.X + 6 * ScaleFactor, _expandcollapseBounds.Y + 15 * ScaleFactor);
+                    PointF MidTop = new(_expandcollapseBounds.X + 12 * ScaleFactor, _expandcollapseBounds.Y + 9 * ScaleFactor);
+                    PointF BottomRight = new(_expandcollapseBounds.X + 18 * ScaleFactor, _expandcollapseBounds.Y + 15 * ScaleFactor);
                     pth.AddLine(BottomLeft, MidTop);
                     pth.AddLine(BottomRight, MidTop);
                     g.DrawPath(formButtonsPen, pth);
@@ -587,7 +654,7 @@ namespace ReaLTaiizor.Controls
             if (!Collapse && ShowValidationButtons)
             {
                 //Draw divider
-                g.DrawLine(new Pen(SkinManager.DividersColor, 1), new Point(0, Height - _footerHeight), new Point(Width, Height - _footerHeight));
+                g.DrawLine(new Pen(SkinManager.DividersColor, 1), new Point(0, Height - (int)(_footerHeight * ScaleFactor)), new Point(Width, Height - (int)(_footerHeight * ScaleFactor)));
             }
         }
 
@@ -598,7 +665,7 @@ namespace ReaLTaiizor.Controls
             if (Collapse)
             {
                 _headerHeight = _headerHeightCollapse;
-                this.Height = _headerHeightCollapse;
+                this.Height = (int)(_headerHeightCollapse * ScaleFactor);
                 Margin = new Padding(16, 1, 16, 0);
 
                 // Is the event registered?
@@ -611,7 +678,7 @@ namespace ReaLTaiizor.Controls
             else
             {
                 _headerHeight = _headerHeightExpand;
-                this.Height = _expandHeight;
+                this.Height = (int)(_expandHeight * ScaleFactor);
                 Margin = new Padding(16, 16, 16, 16);
 
                 // Is the event registered?
@@ -629,15 +696,15 @@ namespace ReaLTaiizor.Controls
         {
             if (!Collapse && ShowValidationButtons)
             {
-                int _buttonWidth = TextRenderer.MeasureText(ValidationButtonText, SkinManager.GetFontByType(MaterialSkinManager.FontType.Button)).Width + 32;
-                _savebuttonBounds = new Rectangle(Width - _buttonPadding - _buttonWidth, Height - _expansionPanelDefaultPadding - _footerButtonHeight, _buttonWidth, _footerButtonHeight);
-                _buttonWidth = TextRenderer.MeasureText(CancelButtonText, SkinManager.GetFontByType(MaterialSkinManager.FontType.Button)).Width + 32;
-                _cancelbuttonBounds = new Rectangle(_savebuttonBounds.Left - _buttonPadding - _buttonWidth, Height - _expansionPanelDefaultPadding - _footerButtonHeight, _buttonWidth, _footerButtonHeight);
+                int _buttonWidth = TextRenderer.MeasureText(ValidationButtonText, SkinManager.GetFontByType(MaterialSkinManager.FontType.Button, ScaleFactor)).Width + 32;
+                _savebuttonBounds = new Rectangle(Width - (int)(_buttonPadding * ScaleFactor) - _buttonWidth, Height - (int)(_expansionPanelDefaultPadding * ScaleFactor) - (int)(_footerButtonHeight * ScaleFactor), _buttonWidth, (int)(_footerButtonHeight * ScaleFactor));
+                _buttonWidth = TextRenderer.MeasureText(CancelButtonText, SkinManager.GetFontByType(MaterialSkinManager.FontType.Button, ScaleFactor)).Width + 32;
+                _cancelbuttonBounds = new Rectangle(_savebuttonBounds.Left - (int)(_buttonPadding * ScaleFactor) - _buttonWidth, Height - (int)(_expansionPanelDefaultPadding * ScaleFactor) - (int)(_footerButtonHeight * ScaleFactor), _buttonWidth, (int)(_footerButtonHeight * ScaleFactor));
 
                 if (_validationButton != null)
                 {
                     _validationButton.Width = _savebuttonBounds.Width;
-                    _validationButton.Left = Width - _buttonPadding - _validationButton.Width;  //Button minimum width management
+                    _validationButton.Left = Width - (int)(_buttonPadding * ScaleFactor) - _validationButton.Width;  //Button minimum width management
                     _validationButton.Top = _savebuttonBounds.Top;
                     _validationButton.Height = _savebuttonBounds.Height;
                     _validationButton.Text = ValidationButtonText;
@@ -647,7 +714,7 @@ namespace ReaLTaiizor.Controls
                 if (_cancelButton != null)
                 {
                     _cancelButton.Width = _cancelbuttonBounds.Width;
-                    _cancelButton.Left = _validationButton.Left - _buttonPadding - _cancelbuttonBounds.Width;  //Button minimum width management
+                    _cancelButton.Left = _validationButton.Left - (int)(_buttonPadding * ScaleFactor) - _cancelbuttonBounds.Width;  //Button minimum width management
                     _cancelButton.Top = _cancelbuttonBounds.Top;
                     _cancelButton.Height = _cancelbuttonBounds.Height;
                     _cancelButton.Text = CancelButtonText;

--- a/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
+++ b/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
@@ -632,7 +632,7 @@ namespace ReaLTaiizor.Controls
                     pth.AddLine(TopLeft, MidBottom);
                     pth.AddLine(TopRight, MidBottom);
                     g.DrawPath(formButtonsPen, pth);
-#warning Magic Numbers
+                    // Note: the numeric offsets above are magic numbers defining the expand glyph shape relative to _expandcollapseBounds and ScaleFactor.
                 }
                 else
                 {

--- a/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
+++ b/src/ReaLTaiizor/Controls/Panel/MaterialExpansionPanel.cs
@@ -158,7 +158,7 @@ namespace ReaLTaiizor.Controls
         public int ExpandHeight
         {
             get => _expandHeight;
-            set { if (value < (int)(_minHeight * ScaleFactor)) { value = (int)(_minHeight * ScaleFactor); } _expandHeight = value; Invalidate(); }
+            set { if (value < _minHeight) { value = _minHeight; } _expandHeight = value; Invalidate(); }
         }
 
         [DefaultValue(true)]

--- a/src/ReaLTaiizor/Controls/RadioButton/MaterialRadioButton.cs
+++ b/src/ReaLTaiizor/Controls/RadioButton/MaterialRadioButton.cs
@@ -191,9 +191,6 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs pevent)
         {
-            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
-
             Graphics g = pevent.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;

--- a/src/ReaLTaiizor/Controls/RadioButton/MaterialRadioButton.cs
+++ b/src/ReaLTaiizor/Controls/RadioButton/MaterialRadioButton.cs
@@ -93,10 +93,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -109,10 +107,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public MaterialRadioButton()

--- a/src/ReaLTaiizor/Controls/RadioButton/MaterialRadioButton.cs
+++ b/src/ReaLTaiizor/Controls/RadioButton/MaterialRadioButton.cs
@@ -81,6 +81,40 @@ namespace ReaLTaiizor.Controls
         private const int RADIOBUTTON_INNER_CIRCLE_SIZE = RADIOBUTTON_SIZE - (2 * RADIOBUTTON_OUTER_CIRCLE_WIDTH);
         private const int TEXT_OFFSET = 26;
 
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         public MaterialRadioButton()
         {
             SetStyle(ControlStyles.DoubleBuffer | ControlStyles.OptimizedDoubleBuffer, true);
@@ -124,25 +158,42 @@ namespace ReaLTaiizor.Controls
 
         private void OnSizeChanged(object sender, EventArgs eventArgs)
         {
-            _boxOffset = (Height / 2) - (int)(RADIOBUTTON_SIZE / 2);
-            _radioButtonBounds = new Rectangle(_boxOffset, _boxOffset, RADIOBUTTON_SIZE, RADIOBUTTON_SIZE);
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
+            _boxOffset = (Height / 2) - (int)((int)(RADIOBUTTON_SIZE * ScaleFactor) / 2);
+            _radioButtonBounds = new Rectangle(_boxOffset, _boxOffset, (int)(RADIOBUTTON_SIZE * ScaleFactor), (int)(RADIOBUTTON_SIZE * ScaleFactor));
         }
 
         public override Size GetPreferredSize(Size proposedSize)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             Size strSize;
 
             using (MaterialNativeTextRenderer NativeText = new(CreateGraphics()))
             {
-                strSize = NativeText.MeasureLogString(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1));
+                strSize = NativeText.MeasureLogString(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor));
             }
 
-            int w = _boxOffset + TEXT_OFFSET + strSize.Width;
-            return Ripple ? new Size(w, HEIGHT_RIPPLE) : new Size(w, HEIGHT_NO_RIPPLE);
+            int w = _boxOffset + (int)(TEXT_OFFSET * ScaleFactor) + strSize.Width;
+            return Ripple ? new Size(w, (int)(HEIGHT_RIPPLE * ScaleFactor)) : new Size(w, (int)(HEIGHT_NO_RIPPLE * ScaleFactor));
+        }
+
+        protected override void OnDpiChangedAfterParent(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
+            base.OnDpiChangedAfterParent(e);
         }
 
         protected override void OnPaint(PaintEventArgs pevent)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             Graphics g = pevent.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
@@ -150,16 +201,16 @@ namespace ReaLTaiizor.Controls
             // clear the control
             g.Clear(Parent.BackColor == Color.Transparent ? ((Parent.Parent == null || (Parent.Parent != null && Parent.Parent.BackColor == Color.Transparent)) ? SkinManager.BackgroundColor : Parent.Parent.BackColor) : Parent.BackColor);
 
-            int RADIOBUTTON_CENTER = _boxOffset + RADIOBUTTON_SIZE_HALF;
+            int RADIOBUTTON_CENTER = _boxOffset + (int)(RADIOBUTTON_SIZE_HALF * ScaleFactor);
             Point animationSource = new(RADIOBUTTON_CENTER, RADIOBUTTON_CENTER);
 
             double animationProgress = _checkAM.GetProgress();
 
             int colorAlpha = Enabled ? (int)(animationProgress * 255.0) : SkinManager.CheckBoxOffDisabledColor.A;
             int backgroundAlpha = Enabled ? (int)(SkinManager.CheckboxOffColor.A * (1.0 - animationProgress)) : SkinManager.CheckBoxOffDisabledColor.A;
-            float animationSize = (float)(animationProgress * 9f);
+            float animationSize = (float)(animationProgress * 9f * ScaleFactor);
             float animationSizeHalf = animationSize / 2;
-            int rippleHeight = (HEIGHT_RIPPLE % 2 == 0) ? HEIGHT_RIPPLE - 3 : HEIGHT_RIPPLE - 2;
+            int rippleHeight = ((int)(HEIGHT_RIPPLE * ScaleFactor) % 2 == 0) ? (int)(HEIGHT_RIPPLE * ScaleFactor) - 3 : (int)(HEIGHT_RIPPLE * ScaleFactor) - 2;
 
             Color RadioColor = Color.FromArgb(colorAlpha, Enabled ? UseAccentColor ? SkinManager.ColorScheme.AccentColor : SkinManager.ColorScheme.PrimaryColor : SkinManager.CheckBoxOffDisabledColor);
 
@@ -190,13 +241,13 @@ namespace ReaLTaiizor.Controls
             // draw radiobutton circle
             using (Pen pen = new(BlendColor(Parent.BackColor, Enabled ? SkinManager.CheckboxOffColor : SkinManager.CheckBoxOffDisabledColor, backgroundAlpha), 2))
             {
-                g.DrawEllipse(pen, new Rectangle(_boxOffset, _boxOffset, RADIOBUTTON_SIZE, RADIOBUTTON_SIZE));
+                g.DrawEllipse(pen, new Rectangle(_boxOffset, _boxOffset, (int)(RADIOBUTTON_SIZE * ScaleFactor), (int)(RADIOBUTTON_SIZE * ScaleFactor)));
             }
 
             if (Enabled)
             {
                 using Pen pen = new(RadioColor, 2);
-                g.DrawEllipse(pen, new Rectangle(_boxOffset, _boxOffset, RADIOBUTTON_SIZE, RADIOBUTTON_SIZE));
+                g.DrawEllipse(pen, new Rectangle(_boxOffset, _boxOffset, (int)(RADIOBUTTON_SIZE * ScaleFactor), (int)(RADIOBUTTON_SIZE * ScaleFactor)));
             }
 
             if (Checked)
@@ -207,8 +258,8 @@ namespace ReaLTaiizor.Controls
 
             // Text
             using MaterialNativeTextRenderer NativeText = new(g);
-            Rectangle textLocation = new(_boxOffset + TEXT_OFFSET, 0, Width, Height);
-            NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1),
+            Rectangle textLocation = new(_boxOffset + (int)(TEXT_OFFSET * ScaleFactor), 0, Width, Height);
+            NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor),
                 Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                 textLocation.Location,
                 textLocation.Size,

--- a/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
+++ b/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
@@ -462,8 +462,8 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs e)
         {
-            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            // ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            // ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
 
             Graphics g = e.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;

--- a/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
+++ b/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
@@ -432,7 +432,7 @@ namespace ReaLTaiizor.Controls
             using (MaterialNativeTextRenderer NativeText = new(CreateGraphics()))
             {
                 textSize = NativeText.MeasureLogString(ShowText ? Text : "", SkinManager.GetLogFontByType(FontType, ScaleFactor));
-                valueSize = NativeText.MeasureLogString(ShowValue ? ValuePrefix + RangeMax.ToString() + ValueSuffix : "", SkinManager.GetLogFontByType(FontType, ScaleFactor));
+                valueSize = NativeText.MeasureLogString(ShowValue ? ValuePrefix + RangeMax + ValueSuffix : "", SkinManager.GetLogFontByType(FontType, ScaleFactor));
             }
             _valueRectangle = new Rectangle(Width - valueSize.Width - ((int)(_thumbRadiusHoverPressed * ScaleFactor) / 4), 0, valueSize.Width + ((int)(_thumbRadiusHoverPressed * ScaleFactor) / 4), Height);
             _textRectangle = new Rectangle(0, 0, textSize.Width + ((int)(_thumbRadiusHoverPressed * ScaleFactor) / 4), Height);

--- a/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
+++ b/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
@@ -510,14 +510,14 @@ namespace ReaLTaiizor.Controls
 
             GraphicsPath _inactiveTrackPath = CreateRoundRect(
                 _sliderRectangle.X + (int)Math.Round(_thumbRadius * ScaleFactor / 2f, MidpointRounding.AwayFromZero),
-                _sliderRectangle.Y + (Height / 2) - (int)Math.Round(_inactiveTrack * ScaleFactor / 2f, MidpointRounding.AwayFromZero),
+                _sliderRectangle.Y + (int)Math.Round(Height / 2f, MidpointRounding.AwayFromZero) - (int)Math.Round(_inactiveTrack * ScaleFactor / 2f, MidpointRounding.AwayFromZero),
                 _sliderRectangle.Width - (int)Math.Round(_thumbRadius * ScaleFactor, MidpointRounding.AwayFromZero),
                 (int)Math.Round(_inactiveTrack * ScaleFactor, MidpointRounding.AwayFromZero),
                 2);
             //g.FillPath(_disabledBrush, (int)(_inactiveTrack * ScaleFactor)Path);
             GraphicsPath _activeTrackPath = CreateRoundRect(
                 _sliderRectangle.X + (int)Math.Round(_thumbRadius * ScaleFactor / 2f, MidpointRounding.AwayFromZero),
-                _sliderRectangle.Y + (Height / 2) - (int)Math.Round(_activeTrack * ScaleFactor / 2f, MidpointRounding.AwayFromZero),
+                _sliderRectangle.Y + (int)Math.Round(Height / 2f, MidpointRounding.AwayFromZero) - (int)Math.Round(_activeTrack * ScaleFactor / 2f, MidpointRounding.AwayFromZero),
                 _indicatorRectangleNormal.X - _sliderRectangle.X,
                 (int)Math.Round(_activeTrack * ScaleFactor, MidpointRounding.AwayFromZero),
                 2);

--- a/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
+++ b/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
@@ -508,9 +508,19 @@ namespace ReaLTaiizor.Controls
             //g.DrawLine(LinePen, _indicatorSize / 2, Height / 2 + (Height - _indicatorSize) / 2, Width - _indicatorSize / 2, Height / 2 + (Height - _indicatorSize) / 2);
             //g.DrawLine(LinePen, _sliderRectangle.X + (_indicatorSize / 2), Height / 2 , _sliderRectangle.Right - (_indicatorSize / 2), Height / 2 );
 
-            GraphicsPath _inactiveTrackPath = CreateRoundRect(_sliderRectangle.X + ((int)(_thumbRadius * ScaleFactor) / 2), _sliderRectangle.Y + (Height / 2) - ((int)(_inactiveTrack * ScaleFactor) / 2), _sliderRectangle.Width - (int)(_thumbRadius * ScaleFactor), (int)(_inactiveTrack * ScaleFactor), 2);
+            GraphicsPath _inactiveTrackPath = CreateRoundRect(
+                _sliderRectangle.X + (int)Math.Round(_thumbRadius * ScaleFactor / 2f, MidpointRounding.AwayFromZero),
+                _sliderRectangle.Y + (Height / 2) - (int)Math.Round(_inactiveTrack * ScaleFactor / 2f, MidpointRounding.AwayFromZero),
+                _sliderRectangle.Width - (int)Math.Round(_thumbRadius * ScaleFactor, MidpointRounding.AwayFromZero),
+                (int)Math.Round(_inactiveTrack * ScaleFactor, MidpointRounding.AwayFromZero),
+                2);
             //g.FillPath(_disabledBrush, (int)(_inactiveTrack * ScaleFactor)Path);
-            GraphicsPath _activeTrackPath = CreateRoundRect(_sliderRectangle.X + ((int)(_thumbRadius * ScaleFactor) / 2), _sliderRectangle.Y + (Height / 2) - ((int)(_activeTrack * ScaleFactor) / 2), _indicatorRectangleNormal.X - _sliderRectangle.X, (int)(_activeTrack * ScaleFactor), 2);
+            GraphicsPath _activeTrackPath = CreateRoundRect(
+                _sliderRectangle.X + (int)Math.Round(_thumbRadius * ScaleFactor / 2f, MidpointRounding.AwayFromZero),
+                _sliderRectangle.Y + (Height / 2) - (int)Math.Round(_activeTrack * ScaleFactor / 2f, MidpointRounding.AwayFromZero),
+                _indicatorRectangleNormal.X - _sliderRectangle.X,
+                (int)Math.Round(_activeTrack * ScaleFactor, MidpointRounding.AwayFromZero),
+                2);
 
             if (Enabled)
             {

--- a/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
+++ b/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
@@ -51,10 +51,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -67,10 +65,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
         #endregion
 

--- a/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
+++ b/src/ReaLTaiizor/Controls/Slider/MaterialSlider.cs
@@ -38,6 +38,40 @@ namespace ReaLTaiizor.Controls
         private const int _thumbRadius = 20;
         private const int _thumbRadiusHoverPressed = 40;
 
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
         #endregion
 
         #region "Public Properties"
@@ -85,8 +119,8 @@ namespace ReaLTaiizor.Controls
                 {
                     _value = value;
                 }
-                //_mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width) - _thumbRadius / 2));
-                _mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width - _thumbRadius)));
+                //_mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width) - (int)(_thumbRadius * ScaleFactor) / 2));
+                _mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width - (int)(_thumbRadius * ScaleFactor))));
                 RecalcutlateIndicator();
             }
         }
@@ -123,8 +157,8 @@ namespace ReaLTaiizor.Controls
             set
             {
                 field = value;
-                //_mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width) - _thumbRadius / 2));
-                _mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width - _thumbRadius)));
+                //_mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width) - (int)(_thumbRadius * ScaleFactor) / 2));
+                _mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width - (int)(_thumbRadius * ScaleFactor))));
                 RecalcutlateIndicator();
             }
         }
@@ -138,8 +172,8 @@ namespace ReaLTaiizor.Controls
             set
             {
                 field = value;
-                //_mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width) - _thumbRadius / 2));
-                _mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width - _thumbRadius)));
+                //_mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width) - (int)(_thumbRadius * ScaleFactor) / 2));
+                _mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width - (int)(_thumbRadius * ScaleFactor))));
                 RecalcutlateIndicator();
             }
         }
@@ -218,7 +252,7 @@ namespace ReaLTaiizor.Controls
             set
             {
                 field = value;
-                Font = SkinManager.GetFontByType(field);
+                Font = SkinManager.GetFontByType(field, ScaleFactor);
                 Refresh();
             }
         } = MaterialSkinManager.FontType.Body1;
@@ -251,7 +285,7 @@ namespace ReaLTaiizor.Controls
             ForeColor = SkinManager.TextHighEmphasisColor; // Color.Black;
             RangeMax = 100;
             RangeMin = 0;
-            Size = new Size(250, _thumbRadiusHoverPressed);
+            Size = new Size(250, (int)(_thumbRadiusHoverPressed * ScaleFactor));
             Text = "My Data";
             Value = 50;
             ValueSuffix = "";
@@ -276,7 +310,7 @@ namespace ReaLTaiizor.Controls
         protected override void OnSizeChanged(EventArgs e)
         {
             base.OnSizeChanged(e);
-            Height = _thumbRadiusHoverPressed;
+            Height = (int)(_thumbRadiusHoverPressed * ScaleFactor);
             UpdateRects();
         }
 
@@ -355,21 +389,21 @@ namespace ReaLTaiizor.Controls
         private void UpdateValue(MouseEventArgs e)
         {
             int v = 0;
-            if (e.X >= _sliderRectangle.X + (_thumbRadius / 2) && e.X <= _sliderRectangle.Right - (_thumbRadius / 2))
+            if (e.X >= _sliderRectangle.X + ((int)(_thumbRadius * ScaleFactor) / 2) && e.X <= _sliderRectangle.Right - ((int)(_thumbRadius * ScaleFactor) / 2))
             {
-                _mouseX = e.X - (_thumbRadius / 2);
-                double ValuePerPx = ((double)(RangeMax - RangeMin)) / (_sliderRectangle.Width - _thumbRadius);
+                _mouseX = e.X - ((int)(_thumbRadius * ScaleFactor) / 2);
+                double ValuePerPx = ((double)(RangeMax - RangeMin)) / (_sliderRectangle.Width - (int)(_thumbRadius * ScaleFactor));
                 v = (int)(ValuePerPx * (_mouseX - _sliderRectangle.X));
                 //if (_valueMax!=0 && v > _valueMax) v = _valueMax;
             }
-            else if (e.X < _sliderRectangle.X)// + (_thumbRadius / 2))
+            else if (e.X < _sliderRectangle.X)// + ((int)(_thumbRadius * ScaleFactor) / 2))
             {
                 _mouseX = _sliderRectangle.X;
                 v = RangeMin;
             }
-            else if (e.X > _sliderRectangle.Right - _thumbRadius)// / 2)
+            else if (e.X > _sliderRectangle.Right - (int)(_thumbRadius * ScaleFactor))// / 2)
             {
-                _mouseX = _sliderRectangle.Right - _thumbRadius;
+                _mouseX = _sliderRectangle.Right - (int)(_thumbRadius * ScaleFactor);
                 v = RangeMax;
             }
 
@@ -390,30 +424,47 @@ namespace ReaLTaiizor.Controls
 
         private void UpdateRects()
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             Size textSize;
             Size valueSize;
             using (MaterialNativeTextRenderer NativeText = new(CreateGraphics()))
             {
-                textSize = NativeText.MeasureLogString(ShowText ? Text : "", SkinManager.GetLogFontByType(FontType));
-                valueSize = NativeText.MeasureLogString(ShowValue ? ValuePrefix + RangeMax.ToString() + ValueSuffix : "", SkinManager.GetLogFontByType(FontType));
+                textSize = NativeText.MeasureLogString(ShowText ? Text : "", SkinManager.GetLogFontByType(FontType, ScaleFactor));
+                valueSize = NativeText.MeasureLogString(ShowValue ? ValuePrefix + RangeMax.ToString() + ValueSuffix : "", SkinManager.GetLogFontByType(FontType, ScaleFactor));
             }
-            _valueRectangle = new Rectangle(Width - valueSize.Width - (_thumbRadiusHoverPressed / 4), 0, valueSize.Width + (_thumbRadiusHoverPressed / 4), Height);
-            _textRectangle = new Rectangle(0, 0, textSize.Width + (_thumbRadiusHoverPressed / 4), Height);
-            _sliderRectangle = new Rectangle(_textRectangle.Right, 0, _valueRectangle.Left - _textRectangle.Right, _thumbRadius);
-            _mouseX = _sliderRectangle.X + ((int)(((double)_value / (double)(RangeMax - RangeMin) * (double)_sliderRectangle.Width) - (_thumbRadius / 2)));
+            _valueRectangle = new Rectangle(Width - valueSize.Width - ((int)(_thumbRadiusHoverPressed * ScaleFactor) / 4), 0, valueSize.Width + ((int)(_thumbRadiusHoverPressed * ScaleFactor) / 4), Height);
+            _textRectangle = new Rectangle(0, 0, textSize.Width + ((int)(_thumbRadiusHoverPressed * ScaleFactor) / 4), Height);
+            _sliderRectangle = new Rectangle(_textRectangle.Right, 0, _valueRectangle.Left - _textRectangle.Right, (int)(_thumbRadius * ScaleFactor));
+            _mouseX = _sliderRectangle.X + ((int)(((double)_value / (double)(RangeMax - RangeMin) * (double)_sliderRectangle.Width) - ((int)(_thumbRadius * ScaleFactor) / 2)));
             RecalcutlateIndicator();
         }
 
         private void RecalcutlateIndicator()
         {
-            _indicatorRectangle = new Rectangle(_mouseX, (Height - _thumbRadius) / 2, _thumbRadius, _thumbRadius);
-            _indicatorRectangleNormal = new Rectangle(_indicatorRectangle.X, (Height / 2) - (_thumbRadius / 2), _thumbRadius, _thumbRadius);
-            _indicatorRectanglePressed = new Rectangle(_indicatorRectangle.X + (_thumbRadius / 2) - (_thumbRadiusHoverPressed / 2), (Height / 2) - (_thumbRadiusHoverPressed / 2), _thumbRadiusHoverPressed, _thumbRadiusHoverPressed);
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
+            _indicatorRectangle = new Rectangle(_mouseX, (Height - (int)(_thumbRadius * ScaleFactor)) / 2, (int)(_thumbRadius * ScaleFactor), (int)(_thumbRadius * ScaleFactor));
+            _indicatorRectangleNormal = new Rectangle(_indicatorRectangle.X, (Height / 2) - ((int)(_thumbRadius * ScaleFactor) / 2), (int)(_thumbRadius * ScaleFactor), (int)(_thumbRadius * ScaleFactor));
+            _indicatorRectanglePressed = new Rectangle(_indicatorRectangle.X + ((int)(_thumbRadius * ScaleFactor) / 2) - ((int)(_thumbRadiusHoverPressed * ScaleFactor) / 2), (Height / 2) - ((int)(_thumbRadiusHoverPressed * ScaleFactor) / 2), (int)(_thumbRadiusHoverPressed * ScaleFactor), (int)(_thumbRadiusHoverPressed * ScaleFactor));
             Invalidate();
+        }
+
+        protected override void OnDpiChangedAfterParent(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
+            base.OnDpiChangedAfterParent(e);
         }
 
         protected override void OnPaint(PaintEventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             Graphics g = e.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;
             g.TextRenderingHint = TextRenderingHint.AntiAlias;
@@ -455,15 +506,15 @@ namespace ReaLTaiizor.Controls
             //_thumbPressedColor = Color.FromArgb((int)(2.55 * 30), (Value == 0 ? Color.Gray : _accentColor));            _thumbHoverColor = Color.FromArgb((int)(2.55 * 15), (Value == 0 ? Color.Gray : _accentColor));
             _thumbHoverColor = Color.FromArgb((int)(2.55 * 15), _accentColor);
             _thumbPressedColor = Color.FromArgb((int)(2.55 * 30), _accentColor);
-            //Pen LinePen = new Pen(_disabledColor, _inactiveTrack);
+            //Pen LinePen = new Pen(_disabledColor, (int)(_inactiveTrack * ScaleFactor));
 
             //Draw track
             //g.DrawLine(LinePen, _indicatorSize / 2, Height / 2 + (Height - _indicatorSize) / 2, Width - _indicatorSize / 2, Height / 2 + (Height - _indicatorSize) / 2);
             //g.DrawLine(LinePen, _sliderRectangle.X + (_indicatorSize / 2), Height / 2 , _sliderRectangle.Right - (_indicatorSize / 2), Height / 2 );
 
-            GraphicsPath _inactiveTrackPath = CreateRoundRect(_sliderRectangle.X + (_thumbRadius / 2), _sliderRectangle.Y + (Height / 2) - (_inactiveTrack / 2), _sliderRectangle.Width - _thumbRadius, _inactiveTrack, 2);
-            //g.FillPath(_disabledBrush, _inactiveTrackPath);
-            GraphicsPath _activeTrackPath = CreateRoundRect(_sliderRectangle.X + (_thumbRadius / 2), _sliderRectangle.Y + (Height / 2) - (_activeTrack / 2), _indicatorRectangleNormal.X - _sliderRectangle.X, _activeTrack, 2);
+            GraphicsPath _inactiveTrackPath = CreateRoundRect(_sliderRectangle.X + ((int)(_thumbRadius * ScaleFactor) / 2), _sliderRectangle.Y + (Height / 2) - ((int)(_inactiveTrack * ScaleFactor) / 2), _sliderRectangle.Width - (int)(_thumbRadius * ScaleFactor), (int)(_inactiveTrack * ScaleFactor), 2);
+            //g.FillPath(_disabledBrush, (int)(_inactiveTrack * ScaleFactor)Path);
+            GraphicsPath _activeTrackPath = CreateRoundRect(_sliderRectangle.X + ((int)(_thumbRadius * ScaleFactor) / 2), _sliderRectangle.Y + (Height / 2) - ((int)(_activeTrack * ScaleFactor) / 2), _indicatorRectangleNormal.X - _sliderRectangle.X, (int)(_activeTrack * ScaleFactor), 2);
 
             if (Enabled)
             {
@@ -509,7 +560,7 @@ namespace ReaLTaiizor.Controls
                 // Draw text
                 NativeText.DrawTransparentText(
                 Text,
-                SkinManager.GetLogFontByType(FontType),
+                SkinManager.GetLogFontByType(FontType, ScaleFactor),
                 Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                 _textRectangle.Location,
                 _textRectangle.Size,
@@ -521,7 +572,7 @@ namespace ReaLTaiizor.Controls
                 // Draw value
                 NativeText.DrawTransparentText(
                     ValuePrefix + Value.ToString() + ValueSuffix,
-                    SkinManager.GetLogFontByType(FontType),
+                    SkinManager.GetLogFontByType(FontType, ScaleFactor),
                     Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                     _valueRectangle.Location,
                     _valueRectangle.Size,

--- a/src/ReaLTaiizor/Controls/SnackBar/MaterialSnackBar.cs
+++ b/src/ReaLTaiizor/Controls/SnackBar/MaterialSnackBar.cs
@@ -49,10 +49,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -65,10 +63,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         #region "Events"

--- a/src/ReaLTaiizor/Controls/SnackBar/MaterialSnackBar.cs
+++ b/src/ReaLTaiizor/Controls/SnackBar/MaterialSnackBar.cs
@@ -24,6 +24,11 @@ namespace ReaLTaiizor.Controls
         private const int LEFT_RIGHT_PADDING = 16;
         private const int BUTTON_PADDING = 8;
         private const int BUTTON_HEIGHT = 36;
+        private const int CLIENT_HEIGHT = 48;
+        private const int CLIENT_WIDTH = 344;
+        private const int MAX_WIDTH = 568;
+        private const int FONT_HEIGHT = 32;
+        private const int DOWN_PADDING = 12;
 
         private MaterialButton _actionButton = new();
         private Timer _duration = new(); // Timer that checks when the drop down is fully visible
@@ -31,6 +36,40 @@ namespace ReaLTaiizor.Controls
         private AnimationManager _AnimationManager;
         private bool _closingAnimationDone = false;
         private bool CloseAnimation = false;
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
 
         #region "Events"
 
@@ -110,9 +149,9 @@ namespace ReaLTaiizor.Controls
 
             this.ActionButtonText = ActionButtonText;
             this.UseAccentColor = UseAccentColor;
-            Height = 48;
-            MinimumSize = new Size(344, 48);
-            MaximumSize = new Size(568, 48);
+            Height = (int)(CLIENT_HEIGHT * ScaleFactor);
+            MinimumSize = new Size((int)(CLIENT_WIDTH * ScaleFactor), (int)(CLIENT_HEIGHT * ScaleFactor));
+            MaximumSize = new Size((int)(MAX_WIDTH * ScaleFactor), (int)(CLIENT_HEIGHT * ScaleFactor));
 
             this.ShowActionButton = ShowActionButton;
 
@@ -183,10 +222,13 @@ namespace ReaLTaiizor.Controls
 
         private void UpdateRects()
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             if (ShowActionButton == true)
             {
-                int _buttonWidth = TextRenderer.MeasureText(ActionButtonText, SkinManager.GetFontByType(MaterialSkinManager.FontType.Button)).Width + 32;
-                Rectangle _actionbuttonBounds = new(Width - BUTTON_PADDING - _buttonWidth, TOP_PADDING_SINGLE_LINE, _buttonWidth, BUTTON_HEIGHT);
+                int _buttonWidth = TextRenderer.MeasureText(ActionButtonText, SkinManager.GetFontByType(MaterialSkinManager.FontType.Button, ScaleFactor)).Width + (int)(FONT_HEIGHT * ScaleFactor);
+                Rectangle _actionbuttonBounds = new(Width - (int)(BUTTON_PADDING * ScaleFactor) - _buttonWidth, (int)(TOP_PADDING_SINGLE_LINE * ScaleFactor), _buttonWidth, (int)(BUTTON_HEIGHT * ScaleFactor));
                 _actionButton.Width = _actionbuttonBounds.Width;
                 _actionButton.Height = _actionbuttonBounds.Height;
                 _actionButton.Text = ActionButtonText;
@@ -197,10 +239,10 @@ namespace ReaLTaiizor.Controls
             {
                 _actionButton.Width = 0;
             }
-            _actionButton.Left = Width - BUTTON_PADDING - _actionButton.Width;  //Button minimum width management
+            _actionButton.Left = Width - (int)(BUTTON_PADDING * ScaleFactor) - _actionButton.Width;  //Button minimum width management
             _actionButton.Visible = ShowActionButton;
 
-            Width = TextRenderer.MeasureText(Text, SkinManager.GetFontByType(MaterialSkinManager.FontType.Body2)).Width + (2 * LEFT_RIGHT_PADDING) + _actionButton.Width + 48;
+            Width = TextRenderer.MeasureText(Text, SkinManager.GetFontByType(MaterialSkinManager.FontType.Body2, ScaleFactor)).Width + (2 * (int)(LEFT_RIGHT_PADDING * ScaleFactor)) + _actionButton.Width + (int)(CLIENT_HEIGHT * ScaleFactor);
             Region = System.Drawing.Region.FromHrgn(CreateRoundRectRgn(0, 0, Width, Height, 6, 6));
 
         }
@@ -213,6 +255,9 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnResize(EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnResize(e);
             UpdateRects();
         }
@@ -220,7 +265,7 @@ namespace ReaLTaiizor.Controls
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            Location = new Point(Convert.ToInt32(Owner.Location.X + (Owner.Width / 2) - (Width / 2)), Convert.ToInt32(Owner.Location.Y + Owner.Height - 60));
+            Location = new Point(Convert.ToInt32(Owner.Location.X + (Owner.Width / 2) - (Width / 2)), Convert.ToInt32(Owner.Location.Y + Owner.Height - Height - DOWN_PADDING * ScaleFactor));
             _AnimationManager.StartNewAnimation(AnimationDirection.In);
             _duration.Start();
         }
@@ -235,6 +280,9 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             Graphics g = e.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;
 
@@ -242,9 +290,9 @@ namespace ReaLTaiizor.Controls
 
             // Calc text Rect
             Rectangle textRect = new(
-                LEFT_RIGHT_PADDING,
+                (int)(LEFT_RIGHT_PADDING * ScaleFactor),
                 0,
-                Width - (2 * LEFT_RIGHT_PADDING) - _actionButton.Width,
+                Width - (2 * (int)(LEFT_RIGHT_PADDING * ScaleFactor)) - _actionButton.Width,
                 Height);
 
             //Draw  Text
@@ -252,14 +300,14 @@ namespace ReaLTaiizor.Controls
             // Draw header text
             NativeText.DrawTransparentText(
                 Text,
-                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body2),
+                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body2, ScaleFactor),
                 SkinManager.SnackBarTextHighEmphasisColor,
                 textRect.Location,
                 textRect.Size,
                 MaterialNativeTextRenderer.TextAlignFlags.Left | MaterialNativeTextRenderer.TextAlignFlags.Middle);
         }
 
-        protected override void OnClosing(CancelEventArgs e)
+        protected override void OnFormClosing(FormClosingEventArgs e)
         {
             e.Cancel = !_closingAnimationDone;
             if (!_closingAnimationDone)
@@ -269,7 +317,7 @@ namespace ReaLTaiizor.Controls
                 _AnimationManager.OnAnimationFinished += _AnimationManager_OnAnimationFinished;
                 _AnimationManager.StartNewAnimation(AnimationDirection.Out);
             }
-            base.OnClosing(e);
+            base.OnFormClosing(e);
         }
 
         void _AnimationManager_OnAnimationFinished(object sender)
@@ -288,7 +336,7 @@ namespace ReaLTaiizor.Controls
         private void InitializeComponent()
         {
             this.SuspendLayout();
-            this.ClientSize = new Size(344, 48);
+            this.ClientSize = new Size((int)(CLIENT_WIDTH * ScaleFactor), (int)(CLIENT_HEIGHT * ScaleFactor));
             this.Name = "SnackBar";
             this.ResumeLayout(false);
         }

--- a/src/ReaLTaiizor/Controls/SnackBar/MaterialSnackBar.cs
+++ b/src/ReaLTaiizor/Controls/SnackBar/MaterialSnackBar.cs
@@ -265,7 +265,7 @@ namespace ReaLTaiizor.Controls
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            Location = new Point(Convert.ToInt32(Owner.Location.X + (Owner.Width / 2) - (Width / 2)), Convert.ToInt32(Owner.Location.Y + Owner.Height - Height - DOWN_PADDING * ScaleFactor));
+            Location = new Point(Convert.ToInt32(Owner.Location.X + (Owner.Width / 2) - (Width / 2)), Convert.ToInt32(Owner.Location.Y + Owner.Height - Height - (DOWN_PADDING * ScaleFactor)));
             _AnimationManager.StartNewAnimation(AnimationDirection.In);
             _duration.Start();
         }

--- a/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
+++ b/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
@@ -210,7 +210,7 @@ namespace ReaLTaiizor.Controls
 
     internal class MaterialToolStripRender : ToolStripProfessionalRenderer, MaterialControlI
     {
-        private float ScaleRatio;
+        private readonly float ScaleRatio;
 
         private float? _scaleRatio; // Cache
         private float ScaleFactor

--- a/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
+++ b/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
@@ -50,10 +50,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -66,10 +64,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public MaterialContextMenuStrip()
@@ -151,10 +147,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -167,10 +161,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public MaterialToolStripMenuItem()
@@ -231,10 +223,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -247,10 +237,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public MaterialToolStripRender(float scaleRatio)

--- a/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
+++ b/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
@@ -3,12 +3,10 @@
 using ReaLTaiizor.Manager;
 using ReaLTaiizor.Util;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Text;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static ReaLTaiizor.Helper.MaterialDrawHelper;
 using static ReaLTaiizor.Util.MaterialAnimations;
@@ -178,7 +176,7 @@ namespace ReaLTaiizor.Controls
         public MaterialToolStripMenuItem()
         {
             AutoSize = false;
-            
+
         }
 
         public override Size GetPreferredSize(Size constrainingSize)
@@ -186,10 +184,10 @@ namespace ReaLTaiizor.Controls
             ScaleFactor = ((MaterialContextMenuStrip)Owner).SkinManager.GetDeviceScaleFactor(Owner);
             ScaleFactorSqrt = ((MaterialContextMenuStrip)Owner).SkinManager.GetDeviceScaleFactorSqrt(Owner);
 
-            var baseSize = base.GetPreferredSize(constrainingSize);
+            Size baseSize = base.GetPreferredSize(constrainingSize);
 
             return new Size(
-                (int)(baseSize.Width),
+                (int)baseSize.Width,
                 (int)(baseSize.Height * ScaleFactor));
 
         }
@@ -204,7 +202,7 @@ namespace ReaLTaiizor.Controls
 
         protected override ToolStripDropDown CreateDefaultDropDown()
         {
-            
+
             ToolStripDropDown baseDropDown = base.CreateDefaultDropDown();
             if (DesignMode)
             {
@@ -245,7 +243,7 @@ namespace ReaLTaiizor.Controls
             {
                 if (!_scaleRatioSqrt.HasValue)
                 {
-                    _scaleRatioSqrt = (float)(Math.Sqrt(ScaleRatio));
+                    _scaleRatioSqrt = (float)Math.Sqrt(ScaleRatio);
                 }
                 return _scaleRatioSqrt.Value;
             }

--- a/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
+++ b/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
@@ -84,11 +84,6 @@ namespace ReaLTaiizor.Controls
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                // Release handle from CreateFont / LogFont
-                ((MaterialToolStripRender)Renderer).Dispose();
-            }
             base.Dispose(disposing);
         }
 
@@ -204,7 +199,6 @@ namespace ReaLTaiizor.Controls
 
         private const int LEFT_PADDING = 16;
         private const int RIGHT_PADDING = 8;
-        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
 
         //Properties for managing the material design properties
         public int Depth { get; set; }
@@ -222,7 +216,6 @@ namespace ReaLTaiizor.Controls
             Rectangle textRect = new((int)(LEFT_PADDING * GetDeviceScaleFactor()), itemRect.Y, itemRect.Width - ((int)(LEFT_PADDING * GetDeviceScaleFactor()) + (int)(RIGHT_PADDING * GetDeviceScaleFactor())), itemRect.Height);
 
             IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body2, GetDeviceScaleFactor());
-            LFontToBeReleased.Add(font);
             using MaterialNativeTextRenderer NativeText = new(g);
             NativeText.DrawTransparentText(e.Text, font,
                 e.Item.Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
@@ -301,17 +294,6 @@ namespace ReaLTaiizor.Controls
             return new Rectangle(0, item.ContentRectangle.Y, item.ContentRectangle.Width, item.ContentRectangle.Height);
         }
 
-        public void Dispose()
-        {
-            foreach (IntPtr handle in LFontToBeReleased)
-            {
-                if (handle != IntPtr.Zero)
-                {
-                    DeleteObject(handle);
-                }
-            }
-            LFontToBeReleased.Clear();
-        }
 
         [DllImport("gdi32.dll", ExactSpelling = true)]
         private static extern bool DeleteObject(IntPtr hObject);

--- a/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
+++ b/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
@@ -40,9 +40,43 @@ namespace ReaLTaiizor.Controls
 
         public event ItemClickStart OnItemClickStart;
 
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         public MaterialContextMenuStrip()
         {
-            Renderer = new MaterialToolStripRender(GetDeviceScaleFactor());
+            Renderer = new MaterialToolStripRender(ScaleFactor);
             AnimationManager = new AnimationManager(false)
             {
                 Increment = 0.07,
@@ -54,30 +88,13 @@ namespace ReaLTaiizor.Controls
             BackColor = SkinManager.BackdropColor;
         }
 
-
-
-        private float GetDeviceScaleFactor()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = DeviceDpi / 96f;
-            return scalingFactor;
-        }
-
-        private float GetDeviceScaleFactorSqrt()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Math.Sqrt((float)DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            return scalingFactor;
-        }
-
         //public override Size GetPreferredSize(Size constrainingSize)
         //{
         //    var baseSize = base.GetPreferredSize(constrainingSize);
 
         //    return new Size(
-        //        (int)(baseSize.Width * GetDeviceScaleFactor()),
-        //        (int)(baseSize.Height * GetDeviceScaleFactor()));
+        //        (int)(baseSize.Width * ScaleFactor),
+        //        (int)(baseSize.Height * ScaleFactor));
 
         //}
 
@@ -125,19 +142,37 @@ namespace ReaLTaiizor.Controls
     public class MaterialToolStripMenuItem : ToolStripMenuItem
     {
 
-        private float GetDeviceScaleFactor()
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
         {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Owner.DeviceDpi / 96f;
-            return scalingFactor;
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = ((MaterialContextMenuStrip)Owner).SkinManager.GetDeviceScaleFactor(Owner);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
         }
-
-        private float GetDeviceScaleFactorSqrt()
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
         {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Math.Sqrt((float)GetCurrentParent().Parent.DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            return scalingFactor;
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = ((MaterialContextMenuStrip)Owner).SkinManager.GetDeviceScaleFactorSqrt(Owner);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
         }
 
         public MaterialToolStripMenuItem()
@@ -148,17 +183,22 @@ namespace ReaLTaiizor.Controls
 
         public override Size GetPreferredSize(Size constrainingSize)
         {
+            ScaleFactor = ((MaterialContextMenuStrip)Owner).SkinManager.GetDeviceScaleFactor(Owner);
+            ScaleFactorSqrt = ((MaterialContextMenuStrip)Owner).SkinManager.GetDeviceScaleFactorSqrt(Owner);
+
             var baseSize = base.GetPreferredSize(constrainingSize);
 
             return new Size(
-                (int)(baseSize.Width * GetDeviceScaleFactor()),
-                (int)(baseSize.Height * GetDeviceScaleFactor()));
+                (int)(baseSize.Width * ScaleFactor),
+                (int)(baseSize.Height * ScaleFactor));
 
         }
 
         protected override void OnOwnerChanged(EventArgs e)
         {
-            Size = new Size((int)(128 * GetDeviceScaleFactor()), (int)(32 * GetDeviceScaleFactor()));
+            ScaleFactor = ((MaterialContextMenuStrip)Owner).SkinManager.GetDeviceScaleFactor(Owner);
+            ScaleFactorSqrt = ((MaterialContextMenuStrip)Owner).SkinManager.GetDeviceScaleFactorSqrt(Owner);
+            Size = new Size((int)(128 * ScaleFactor), (int)(32 * ScaleFactor));
             // Do not calc this in MaterialToolStripMenuItem() or the owner or parent is null!!!
         }
 
@@ -182,14 +222,37 @@ namespace ReaLTaiizor.Controls
     {
         private float ScaleRatio;
 
-        private float GetDeviceScaleFactor()
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
         {
-            return ScaleRatio;
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = ScaleRatio;
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
         }
-
-        private float GetDeviceScaleFactorSqrt()
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
         {
-            return (float)(Math.Sqrt(ScaleRatio));
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = (float)(Math.Sqrt(ScaleRatio));
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
         }
 
         public MaterialToolStripRender(float scaleRatio)
@@ -213,9 +276,9 @@ namespace ReaLTaiizor.Controls
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
 
             Rectangle itemRect = GetItemRect(e.Item);
-            Rectangle textRect = new((int)(LEFT_PADDING * GetDeviceScaleFactor()), itemRect.Y, itemRect.Width - ((int)(LEFT_PADDING * GetDeviceScaleFactor()) + (int)(RIGHT_PADDING * GetDeviceScaleFactor())), itemRect.Height);
+            Rectangle textRect = new((int)(LEFT_PADDING * ScaleFactor), itemRect.Y, itemRect.Width - ((int)(LEFT_PADDING * ScaleFactor) + (int)(RIGHT_PADDING * ScaleFactor)), itemRect.Height);
 
-            IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body2, GetDeviceScaleFactor());
+            IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body2, ScaleFactor);
             using MaterialNativeTextRenderer NativeText = new(g);
             NativeText.DrawTransparentText(e.Text, font,
                 e.Item.Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
@@ -281,9 +344,9 @@ namespace ReaLTaiizor.Controls
             using GraphicsPath arrowPath = new();
             arrowPath.AddLines(
                 new[] {
-                        new Point(arrowMiddle.X - (int)(ARROW_SIZE * GetDeviceScaleFactor()), arrowMiddle.Y - (int)(ARROW_SIZE * GetDeviceScaleFactor())),
+                        new Point(arrowMiddle.X - (int)(ARROW_SIZE * ScaleFactor), arrowMiddle.Y - (int)(ARROW_SIZE * ScaleFactor)),
                         new Point(arrowMiddle.X, arrowMiddle.Y),
-                        new Point(arrowMiddle.X - (int)(ARROW_SIZE * GetDeviceScaleFactor()), arrowMiddle.Y + (int)(ARROW_SIZE * GetDeviceScaleFactor())) });
+                        new Point(arrowMiddle.X - (int)(ARROW_SIZE * ScaleFactor), arrowMiddle.Y + (int)(ARROW_SIZE * ScaleFactor)) });
             arrowPath.CloseFigure();
 
             g.FillPath(arrowBrush, arrowPath);
@@ -293,10 +356,6 @@ namespace ReaLTaiizor.Controls
         {
             return new Rectangle(0, item.ContentRectangle.Y, item.ContentRectangle.Width, item.ContentRectangle.Height);
         }
-
-
-        [DllImport("gdi32.dll", ExactSpelling = true)]
-        private static extern bool DeleteObject(IntPtr hObject);
 
     }
 

--- a/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
+++ b/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
@@ -2,10 +2,13 @@
 
 using ReaLTaiizor.Manager;
 using ReaLTaiizor.Util;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Text;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static ReaLTaiizor.Helper.MaterialDrawHelper;
 using static ReaLTaiizor.Util.MaterialAnimations;
@@ -39,8 +42,7 @@ namespace ReaLTaiizor.Controls
 
         public MaterialContextMenuStrip()
         {
-            Renderer = new MaterialToolStripRender();
-
+            Renderer = new MaterialToolStripRender(GetDeviceScaleFactor());
             AnimationManager = new AnimationManager(false)
             {
                 Increment = 0.07,
@@ -52,12 +54,52 @@ namespace ReaLTaiizor.Controls
             BackColor = SkinManager.BackdropColor;
         }
 
+
+
+        private float GetDeviceScaleFactor()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = DeviceDpi / 96f;
+            return scalingFactor;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
+        }
+
+        //public override Size GetPreferredSize(Size constrainingSize)
+        //{
+        //    var baseSize = base.GetPreferredSize(constrainingSize);
+
+        //    return new Size(
+        //        (int)(baseSize.Width * GetDeviceScaleFactor()),
+        //        (int)(baseSize.Height * GetDeviceScaleFactor()));
+
+        //}
+
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Release handle from CreateFont / LogFont
+                ((MaterialToolStripRender)Renderer).Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
         protected override void OnMouseUp(MouseEventArgs mea)
         {
             base.OnMouseUp(mea);
 
             AnimationSource = mea.Location;
         }
+
+        public override ToolStripItemCollection Items => base.Items;
 
         private ToolStripItemClickedEventArgs _delayesArgs;
 
@@ -87,14 +129,47 @@ namespace ReaLTaiizor.Controls
 
     public class MaterialToolStripMenuItem : ToolStripMenuItem
     {
+
+        private float GetDeviceScaleFactor()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Owner.DeviceDpi / 96f;
+            return scalingFactor;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)GetCurrentParent().Parent.DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
+        }
+
         public MaterialToolStripMenuItem()
         {
             AutoSize = false;
-            Size = new Size(128, 32);
+            
+        }
+
+        public override Size GetPreferredSize(Size constrainingSize)
+        {
+            var baseSize = base.GetPreferredSize(constrainingSize);
+
+            return new Size(
+                (int)(baseSize.Width * GetDeviceScaleFactor()),
+                (int)(baseSize.Height * GetDeviceScaleFactor()));
+
+        }
+
+        protected override void OnOwnerChanged(EventArgs e)
+        {
+            Size = new Size((int)(128 * GetDeviceScaleFactor()), (int)(32 * GetDeviceScaleFactor()));
+            // Do not calc this in MaterialToolStripMenuItem() or the owner or parent is null!!!
         }
 
         protected override ToolStripDropDown CreateDefaultDropDown()
         {
+            
             ToolStripDropDown baseDropDown = base.CreateDefaultDropDown();
             if (DesignMode)
             {
@@ -110,8 +185,26 @@ namespace ReaLTaiizor.Controls
 
     internal class MaterialToolStripRender : ToolStripProfessionalRenderer, MaterialControlI
     {
+        private float ScaleRatio;
+
+        private float GetDeviceScaleFactor()
+        {
+            return ScaleRatio;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            return (float)(Math.Sqrt(ScaleRatio));
+        }
+
+        public MaterialToolStripRender(float scaleRatio)
+        {
+            ScaleRatio = scaleRatio;
+        }
+
         private const int LEFT_PADDING = 16;
         private const int RIGHT_PADDING = 8;
+        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
 
         //Properties for managing the material design properties
         public int Depth { get; set; }
@@ -126,10 +219,12 @@ namespace ReaLTaiizor.Controls
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
 
             Rectangle itemRect = GetItemRect(e.Item);
-            Rectangle textRect = new(LEFT_PADDING, itemRect.Y, itemRect.Width - (LEFT_PADDING + RIGHT_PADDING), itemRect.Height);
+            Rectangle textRect = new((int)(LEFT_PADDING * GetDeviceScaleFactor()), itemRect.Y, itemRect.Width - ((int)(LEFT_PADDING * GetDeviceScaleFactor()) + (int)(RIGHT_PADDING * GetDeviceScaleFactor())), itemRect.Height);
 
+            IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body2, GetDeviceScaleFactor());
+            LFontToBeReleased.Add(font);
             using MaterialNativeTextRenderer NativeText = new(g);
-            NativeText.DrawTransparentText(e.Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body2),
+            NativeText.DrawTransparentText(e.Text, font,
                 e.Item.Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                 textRect.Location,
                 textRect.Size,
@@ -193,9 +288,9 @@ namespace ReaLTaiizor.Controls
             using GraphicsPath arrowPath = new();
             arrowPath.AddLines(
                 new[] {
-                        new Point(arrowMiddle.X - ARROW_SIZE, arrowMiddle.Y - ARROW_SIZE),
+                        new Point(arrowMiddle.X - (int)(ARROW_SIZE * GetDeviceScaleFactor()), arrowMiddle.Y - (int)(ARROW_SIZE * GetDeviceScaleFactor())),
                         new Point(arrowMiddle.X, arrowMiddle.Y),
-                        new Point(arrowMiddle.X - ARROW_SIZE, arrowMiddle.Y + ARROW_SIZE) });
+                        new Point(arrowMiddle.X - (int)(ARROW_SIZE * GetDeviceScaleFactor()), arrowMiddle.Y + (int)(ARROW_SIZE * GetDeviceScaleFactor())) });
             arrowPath.CloseFigure();
 
             g.FillPath(arrowBrush, arrowPath);
@@ -205,6 +300,22 @@ namespace ReaLTaiizor.Controls
         {
             return new Rectangle(0, item.ContentRectangle.Y, item.ContentRectangle.Width, item.ContentRectangle.Height);
         }
+
+        public void Dispose()
+        {
+            foreach (IntPtr handle in LFontToBeReleased)
+            {
+                if (handle != IntPtr.Zero)
+                {
+                    DeleteObject(handle);
+                }
+            }
+            LFontToBeReleased.Clear();
+        }
+
+        [DllImport("gdi32.dll", ExactSpelling = true)]
+        private static extern bool DeleteObject(IntPtr hObject);
+
     }
 
     #endregion

--- a/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
+++ b/src/ReaLTaiizor/Controls/Strip/MaterialContextMenuStrip.cs
@@ -189,7 +189,7 @@ namespace ReaLTaiizor.Controls
             var baseSize = base.GetPreferredSize(constrainingSize);
 
             return new Size(
-                (int)(baseSize.Width * ScaleFactor),
+                (int)(baseSize.Width),
                 (int)(baseSize.Height * ScaleFactor));
 
         }

--- a/src/ReaLTaiizor/Controls/Switch/MaterialSwitch.cs
+++ b/src/ReaLTaiizor/Controls/Switch/MaterialSwitch.cs
@@ -261,11 +261,11 @@ namespace ReaLTaiizor.Controls
             RectangleF thumbBounds = new((int)(TRACK_CENTER_X_BEGIN * ScaleFactor) + OffsetX - (int)(THUMB_SIZE_HALF * ScaleFactor), (int)(TRACK_CENTER_Y * ScaleFactor) - (int)(THUMB_SIZE_HALF * ScaleFactor), (int)(THUMB_SIZE * ScaleFactor), (int)(THUMB_SIZE * ScaleFactor));
             using (SolidBrush shadowBrush = new(Color.FromArgb(12, 0, 0, 0)))
             {
-                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 2 * ScaleFactor, thumbBounds.Y - 1 * ScaleFactor, thumbBounds.Width + 4 * ScaleFactor, thumbBounds.Height + 6 * ScaleFactor));
-                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 1 * ScaleFactor, thumbBounds.Y - 1 * ScaleFactor, thumbBounds.Width + 2 * ScaleFactor, thumbBounds.Height + 4 * ScaleFactor));
-                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 0 * ScaleFactor, thumbBounds.Y - 0 * ScaleFactor, thumbBounds.Width + 0 * ScaleFactor, thumbBounds.Height + 2 * ScaleFactor));
-                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 0 * ScaleFactor, thumbBounds.Y + 2 * ScaleFactor, thumbBounds.Width + 0 * ScaleFactor, thumbBounds.Height + 0 * ScaleFactor));
-                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 0 * ScaleFactor, thumbBounds.Y + 1 * ScaleFactor, thumbBounds.Width + 0 * ScaleFactor, thumbBounds.Height + 0 * ScaleFactor));
+                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - (2 * ScaleFactor), thumbBounds.Y - (1 * ScaleFactor), thumbBounds.Width + (4 * ScaleFactor), thumbBounds.Height + (6 * ScaleFactor)));
+                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - (1 * ScaleFactor), thumbBounds.Y - (1 * ScaleFactor), thumbBounds.Width + (2 * ScaleFactor), thumbBounds.Height + (4 * ScaleFactor)));
+                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - (0 * ScaleFactor), thumbBounds.Y - (0 * ScaleFactor), thumbBounds.Width + (0 * ScaleFactor), thumbBounds.Height + (2 * ScaleFactor)));
+                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - (0 * ScaleFactor), thumbBounds.Y + (2 * ScaleFactor), thumbBounds.Width + (0 * ScaleFactor), thumbBounds.Height + (0 * ScaleFactor)));
+                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - (0 * ScaleFactor), thumbBounds.Y + (1 * ScaleFactor), thumbBounds.Width + (0 * ScaleFactor), thumbBounds.Height + (0 * ScaleFactor)));
             }
 
             // draw Thumb

--- a/src/ReaLTaiizor/Controls/Switch/MaterialSwitch.cs
+++ b/src/ReaLTaiizor/Controls/Switch/MaterialSwitch.cs
@@ -99,10 +99,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -115,10 +113,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public MaterialSwitch()

--- a/src/ReaLTaiizor/Controls/Switch/MaterialSwitch.cs
+++ b/src/ReaLTaiizor/Controls/Switch/MaterialSwitch.cs
@@ -196,8 +196,8 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs pevent)
         {
-            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            // ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            // ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
 
             Graphics g = pevent.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;

--- a/src/ReaLTaiizor/Controls/Switch/MaterialSwitch.cs
+++ b/src/ReaLTaiizor/Controls/Switch/MaterialSwitch.cs
@@ -171,7 +171,7 @@ namespace ReaLTaiizor.Controls
             ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
             _trackOffsetY = (Height / 2) - (int)(THUMB_SIZE_HALF * ScaleFactor);
 
-            TRACK_CENTER_Y = (int)(Height / 2 / ScaleFactor);
+            TRACK_CENTER_Y = (int)(Height / 2f / ScaleFactor);
             // To avoid additional ScaleFactor applying.
             TRACK_CENTER_X_BEGIN = TRACK_CENTER_Y;
             TRACK_CENTER_X_END = TRACK_CENTER_X_BEGIN + TRACK_SIZE_WIDTH - (TRACK_RADIUS * 2);

--- a/src/ReaLTaiizor/Controls/Switch/MaterialSwitch.cs
+++ b/src/ReaLTaiizor/Controls/Switch/MaterialSwitch.cs
@@ -76,6 +76,7 @@ namespace ReaLTaiizor.Controls
         private const int TRACK_SIZE_HEIGHT = (int)14;
         private const int TRACK_SIZE_WIDTH = (int)36;
         private const int TRACK_RADIUS = (int)(TRACK_SIZE_HEIGHT / 2);
+        private const int TEXT_OFFSET = THUMB_SIZE;
 
         private int TRACK_CENTER_Y;
         private int TRACK_CENTER_X_BEGIN;
@@ -85,6 +86,40 @@ namespace ReaLTaiizor.Controls
         private const int RIPPLE_DIAMETER = 37;
 
         private int _trackOffsetY;
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
 
         public MaterialSwitch()
         {
@@ -132,10 +167,12 @@ namespace ReaLTaiizor.Controls
         protected override void OnSizeChanged(EventArgs e)
         {
             base.OnSizeChanged(e);
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            _trackOffsetY = (Height / 2) - (int)(THUMB_SIZE_HALF * ScaleFactor);
 
-            _trackOffsetY = (Height / 2) - THUMB_SIZE_HALF;
-
-            TRACK_CENTER_Y = _trackOffsetY + THUMB_SIZE_HALF - 1;
+            TRACK_CENTER_Y = (int)(Height / 2 / ScaleFactor);
+            // To avoid additional ScaleFactor applying.
             TRACK_CENTER_X_BEGIN = TRACK_CENTER_Y;
             TRACK_CENTER_X_END = TRACK_CENTER_X_BEGIN + TRACK_SIZE_WIDTH - (TRACK_RADIUS * 2);
             TRACK_CENTER_X_DELTA = TRACK_CENTER_X_END - TRACK_CENTER_X_BEGIN;
@@ -143,21 +180,25 @@ namespace ReaLTaiizor.Controls
 
         public override Size GetPreferredSize(Size proposedSize)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             Size strSize;
             using (MaterialNativeTextRenderer NativeText = new(CreateGraphics()))
             {
-                strSize = NativeText.MeasureLogString(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1));
+                strSize = NativeText.MeasureLogString(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor));
             }
-            int w = TRACK_SIZE_WIDTH + THUMB_SIZE + strSize.Width;
-            return Ripple ? new Size(w, RIPPLE_DIAMETER) : new Size(w, THUMB_SIZE);
+            int w = (int)(TRACK_SIZE_WIDTH * ScaleFactor) + (int)(THUMB_SIZE * ScaleFactor) + strSize.Width;
+            return Ripple ? new Size(w, (int)(RIPPLE_DIAMETER * ScaleFactor)) : new Size(w, (int)(THUMB_SIZE * ScaleFactor));
         }
 
         private static readonly Point[] CheckmarkLine = { new(3, 8), new(7, 12), new(14, 5) };
 
-        private const int TEXT_OFFSET = THUMB_SIZE;
-
         protected override void OnPaint(PaintEventArgs pevent)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             Graphics g = pevent.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
@@ -172,7 +213,7 @@ namespace ReaLTaiizor.Controls
                         Enabled ? UseAccentColor ? SkinManager.ColorScheme.AccentColor : SkinManager.ColorScheme.PrimaryColor : BlendColor(UseAccentColor ? SkinManager.ColorScheme.AccentColor : SkinManager.ColorScheme.PrimaryColor, SkinManager.SwitchOffDisabledThumbColor, 197), // On color
                         animationProgress * 255); // Blend amount
 
-            using (GraphicsPath path = CreateRoundRect(new Rectangle(TRACK_CENTER_X_BEGIN - TRACK_RADIUS, TRACK_CENTER_Y - (TRACK_SIZE_HEIGHT / 2), TRACK_SIZE_WIDTH, TRACK_SIZE_HEIGHT), TRACK_RADIUS))
+            using (GraphicsPath path = CreateRoundRect(new Rectangle((int)(TRACK_CENTER_X_BEGIN * ScaleFactor) - (int)(TRACK_RADIUS * ScaleFactor), (int)(TRACK_CENTER_Y * ScaleFactor) - ((int)(TRACK_SIZE_HEIGHT * ScaleFactor) / 2), (int)(TRACK_SIZE_WIDTH * ScaleFactor), (int)(TRACK_SIZE_HEIGHT * ScaleFactor)), (int)(TRACK_RADIUS * ScaleFactor)))
             {
                 using SolidBrush trackBrush = new(
                     Color.FromArgb(Enabled ? SkinManager.SwitchOffTrackColor.A : SkinManager.BackgroundDisabledColor.A, // Track alpha
@@ -185,7 +226,7 @@ namespace ReaLTaiizor.Controls
             }
 
             // Calculate animation movement X position
-            int OffsetX = (int)(TRACK_CENTER_X_DELTA * animationProgress);
+            int OffsetX = (int)((int)(TRACK_CENTER_X_DELTA * ScaleFactor) * animationProgress);
 
             // Ripple
             int rippleSize = (Height % 2 == 0) ? Height - 2 : Height - 3;
@@ -202,7 +243,7 @@ namespace ReaLTaiizor.Controls
                     int rippleAnimatedDiameter = (_rippleAM.GetDirection(i) == AnimationDirection.InOutIn) ? (int)(rippleSize * (0.7 + (0.3 * rippleAnimProgress))) : rippleSize;
 
                     using SolidBrush rippleBrush = new(Color.FromArgb((int)(40 * rippleAnimProgress), rippleColor.RemoveAlpha()));
-                    g.FillEllipse(rippleBrush, new Rectangle(TRACK_CENTER_X_BEGIN + OffsetX - (rippleAnimatedDiameter / 2), TRACK_CENTER_Y - (rippleAnimatedDiameter / 2), rippleAnimatedDiameter, rippleAnimatedDiameter));
+                    g.FillEllipse(rippleBrush, new Rectangle((int)(TRACK_CENTER_X_BEGIN * ScaleFactor) + OffsetX - (rippleAnimatedDiameter / 2), (int)(TRACK_CENTER_Y * ScaleFactor) - (rippleAnimatedDiameter / 2), rippleAnimatedDiameter, rippleAnimatedDiameter));
                 }
             }
 
@@ -213,18 +254,18 @@ namespace ReaLTaiizor.Controls
                 int rippleAnimatedDiameter = (int)(rippleSize * (0.7 + (0.3 * rippleAnimProgress)));
 
                 using SolidBrush rippleBrush = new(Color.FromArgb((int)(40 * rippleAnimProgress), rippleColor.RemoveAlpha()));
-                g.FillEllipse(rippleBrush, new Rectangle(TRACK_CENTER_X_BEGIN + OffsetX - (rippleAnimatedDiameter / 2), TRACK_CENTER_Y - (rippleAnimatedDiameter / 2), rippleAnimatedDiameter, rippleAnimatedDiameter));
+                g.FillEllipse(rippleBrush, new Rectangle((int)(TRACK_CENTER_X_BEGIN * ScaleFactor) + OffsetX - (rippleAnimatedDiameter / 2), (int)(TRACK_CENTER_Y * ScaleFactor) - (rippleAnimatedDiameter / 2), rippleAnimatedDiameter, rippleAnimatedDiameter));
             }
 
             // draw Thumb Shadow
-            RectangleF thumbBounds = new(TRACK_CENTER_X_BEGIN + OffsetX - THUMB_SIZE_HALF, TRACK_CENTER_Y - THUMB_SIZE_HALF, THUMB_SIZE, THUMB_SIZE);
+            RectangleF thumbBounds = new((int)(TRACK_CENTER_X_BEGIN * ScaleFactor) + OffsetX - (int)(THUMB_SIZE_HALF * ScaleFactor), (int)(TRACK_CENTER_Y * ScaleFactor) - (int)(THUMB_SIZE_HALF * ScaleFactor), (int)(THUMB_SIZE * ScaleFactor), (int)(THUMB_SIZE * ScaleFactor));
             using (SolidBrush shadowBrush = new(Color.FromArgb(12, 0, 0, 0)))
             {
-                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 2, thumbBounds.Y - 1, thumbBounds.Width + 4, thumbBounds.Height + 6));
-                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 1, thumbBounds.Y - 1, thumbBounds.Width + 2, thumbBounds.Height + 4));
-                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 0, thumbBounds.Y - 0, thumbBounds.Width + 0, thumbBounds.Height + 2));
-                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 0, thumbBounds.Y + 2, thumbBounds.Width + 0, thumbBounds.Height + 0));
-                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 0, thumbBounds.Y + 1, thumbBounds.Width + 0, thumbBounds.Height + 0));
+                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 2 * ScaleFactor, thumbBounds.Y - 1 * ScaleFactor, thumbBounds.Width + 4 * ScaleFactor, thumbBounds.Height + 6 * ScaleFactor));
+                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 1 * ScaleFactor, thumbBounds.Y - 1 * ScaleFactor, thumbBounds.Width + 2 * ScaleFactor, thumbBounds.Height + 4 * ScaleFactor));
+                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 0 * ScaleFactor, thumbBounds.Y - 0 * ScaleFactor, thumbBounds.Width + 0 * ScaleFactor, thumbBounds.Height + 2 * ScaleFactor));
+                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 0 * ScaleFactor, thumbBounds.Y + 2 * ScaleFactor, thumbBounds.Width + 0 * ScaleFactor, thumbBounds.Height + 0 * ScaleFactor));
+                g.FillEllipse(shadowBrush, new RectangleF(thumbBounds.X - 0 * ScaleFactor, thumbBounds.Y + 1 * ScaleFactor, thumbBounds.Width + 0 * ScaleFactor, thumbBounds.Height + 0 * ScaleFactor));
             }
 
             // draw Thumb
@@ -235,10 +276,10 @@ namespace ReaLTaiizor.Controls
 
             // draw text
             using MaterialNativeTextRenderer NativeText = new(g);
-            Rectangle textLocation = new(TEXT_OFFSET + TRACK_SIZE_WIDTH, 0, Width - (TEXT_OFFSET + TRACK_SIZE_WIDTH), Height);
+            Rectangle textLocation = new((int)(TEXT_OFFSET * ScaleFactor) + (int)(TRACK_SIZE_WIDTH * ScaleFactor), 0, Width - ((int)(TEXT_OFFSET * ScaleFactor) + (int)(TRACK_SIZE_WIDTH * ScaleFactor)), Height);
             NativeText.DrawTransparentText(
                 Text,
-                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1),
+                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor),
                 Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                 textLocation.Location,
                 textLocation.Size,
@@ -247,7 +288,7 @@ namespace ReaLTaiizor.Controls
 
         private Bitmap DrawCheckMarkBitmap()
         {
-            Bitmap checkMark = new(THUMB_SIZE, THUMB_SIZE);
+            Bitmap checkMark = new((int)(THUMB_SIZE * ScaleFactor), (int)(THUMB_SIZE * ScaleFactor));
             Graphics g = Graphics.FromImage(checkMark);
 
             // clear everything, transparent

--- a/src/ReaLTaiizor/Controls/TabSelector/MaterialTabSelector.cs
+++ b/src/ReaLTaiizor/Controls/TabSelector/MaterialTabSelector.cs
@@ -138,8 +138,43 @@ namespace ReaLTaiizor.Controls
         private const int TAB_HEADER_PADDING = 24;
         private const int TAB_WIDTH_MIN = 160;
         private const int TAB_WIDTH_MAX = 264;
+        private const int DEFAULT_INDICATOR_HEIGHT = 2;
 
         private int _tab_over_index = -1;
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
 
         [Category("Appearance")]
         public CustomCharacterCasing CharacterCasing
@@ -202,8 +237,11 @@ namespace ReaLTaiizor.Controls
 
         public MaterialTabSelector()
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             SetStyle(ControlStyles.DoubleBuffer | ControlStyles.OptimizedDoubleBuffer, true);
-            TabIndicatorHeight = 2;
+            TabIndicatorHeight = DEFAULT_INDICATOR_HEIGHT;
             TabLabel = TabLabelStyle.Text;
 
             Size = new Size(480, 48);
@@ -218,8 +256,11 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnCreateControl()
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnCreateControl();
-            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1);
+            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
         }
 
         protected override void OnPaint(PaintEventArgs e)
@@ -257,7 +298,7 @@ namespace ReaLTaiizor.Controls
             if (_tab_over_index >= 0)
             {
                 //Change mouse over tab background color
-                g.FillRectangle(SkinManager.BackgroundHoverBrush, _tabRects[_tab_over_index].X, _tabRects[_tab_over_index].Y, _tabRects[_tab_over_index].Width, _tabRects[_tab_over_index].Height - TabIndicatorHeight);
+                g.FillRectangle(SkinManager.BackgroundHoverBrush, _tabRects[_tab_over_index].X, _tabRects[_tab_over_index].Y, _tabRects[_tab_over_index].Width, _tabRects[_tab_over_index].Height - (int)(TabIndicatorHeight * ScaleFactor));
             }
 
             foreach (System.Windows.Forms.TabPage tabPage in BaseTabControl.TabPages)
@@ -269,7 +310,7 @@ namespace ReaLTaiizor.Controls
                     // Text
                     using MaterialNativeTextRenderer NativeText = new(g);
                     Size textSize = TextRenderer.MeasureText(BaseTabControl.TabPages[currentTabIndex].Text, Font);
-                    Rectangle textLocation = new(_tabRects[currentTabIndex].X + (TAB_HEADER_PADDING / 2), _tabRects[currentTabIndex].Y, _tabRects[currentTabIndex].Width - TAB_HEADER_PADDING, _tabRects[currentTabIndex].Height);
+                    Rectangle textLocation = new(_tabRects[currentTabIndex].X + ((int)(TAB_HEADER_PADDING * ScaleFactor) / 2), _tabRects[currentTabIndex].Y, _tabRects[currentTabIndex].Width - (int)(TAB_HEADER_PADDING * ScaleFactor), _tabRects[currentTabIndex].Height);
 
                     if (TabLabel == TabLabelStyle.IconAndText)
                     {
@@ -277,7 +318,7 @@ namespace ReaLTaiizor.Controls
                         textLocation.Height = 10;
                     }
 
-                    if ((TAB_HEADER_PADDING * 2) + textSize.Width < TAB_WIDTH_MAX)
+                    if (((int)(TAB_HEADER_PADDING * ScaleFactor) * 2) + textSize.Width < (int)(TAB_WIDTH_MAX * ScaleFactor))
                     {
                         NativeText.DrawTransparentText(
                         CharacterCasing == CustomCharacterCasing.Upper ? tabPage.Text.ToUpper() :
@@ -300,7 +341,7 @@ namespace ReaLTaiizor.Controls
                         CharacterCasing == CustomCharacterCasing.Upper ? tabPage.Text.ToUpper() :
                         CharacterCasing == CustomCharacterCasing.Lower ? tabPage.Text.ToLower() :
                         CharacterCasing == CustomCharacterCasing.Proper ? textInfo.ToTitleCase(tabPage.Text.ToLower()) : tabPage.Text,
-                        SkinManager.GetFontByType(MaterialSkinManager.FontType.Body2),
+                        SkinManager.GetFontByType(MaterialSkinManager.FontType.Body2, ScaleFactor),
                         Color.FromArgb(CalculateTextAlpha(currentTabIndex, animationProgress), SkinManager.ColorScheme.TextColor),
                         textLocation.Location,
                         textLocation.Size,
@@ -314,9 +355,9 @@ namespace ReaLTaiizor.Controls
                     if (BaseTabControl.ImageList != null && (!string.IsNullOrEmpty(tabPage.ImageKey) | tabPage.ImageIndex > -1))
                     {
                         Rectangle iconRect = new(
-                            _tabRects[currentTabIndex].X + (_tabRects[currentTabIndex].Width / 2) - (ICON_SIZE / 2),
-                            _tabRects[currentTabIndex].Y + (_tabRects[currentTabIndex].Height / 2) - (ICON_SIZE / 2),
-                            ICON_SIZE, ICON_SIZE);
+                            _tabRects[currentTabIndex].X + (_tabRects[currentTabIndex].Width / 2) - ((int)(ICON_SIZE * ScaleFactor) / 2),
+                            _tabRects[currentTabIndex].Y + (_tabRects[currentTabIndex].Height / 2) - ((int)(ICON_SIZE * ScaleFactor) / 2),
+                            (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
                         if (TabLabel == TabLabelStyle.IconAndText)
                         {
                             iconRect.Y = 12;
@@ -331,11 +372,11 @@ namespace ReaLTaiizor.Controls
             Rectangle previousActiveTabRect = _tabRects[previousSelectedTabIndexIfHasOne];
             Rectangle activeTabPageRect = _tabRects[BaseTabControl.SelectedIndex];
 
-            int y = activeTabPageRect.Bottom - TabIndicatorHeight;
+            int y = activeTabPageRect.Bottom - (int)(TabIndicatorHeight * ScaleFactor);
             int x = previousActiveTabRect.X + (int)((activeTabPageRect.X - previousActiveTabRect.X) * animationProgress);
             int width = previousActiveTabRect.Width + (int)((activeTabPageRect.Width - previousActiveTabRect.Width) * animationProgress);
 
-            g.FillRectangle(SkinManager.ColorScheme.AccentBrush, x, y, width, TabIndicatorHeight);
+            g.FillRectangle(SkinManager.ColorScheme.AccentBrush, x, y, width, (int)(TabIndicatorHeight * ScaleFactor));
         }
 
         private int CalculateTextAlpha(int tabIndex, double animationProgress)
@@ -379,6 +420,22 @@ namespace ReaLTaiizor.Controls
             }
 
             _animationSource = e.Location;
+        }
+
+        protected override void OnDpiChangedAfterParent(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
+            base.OnDpiChangedAfterParent(e);
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
+            base.OnResize(e);
         }
 
         protected override void OnMouseMove(MouseEventArgs e)
@@ -466,7 +523,7 @@ namespace ReaLTaiizor.Controls
             {
                 foreach (System.Windows.Forms.TabPage TP in BaseTabControl.TabPages)
                 {
-                    TitleLenght += (TAB_HEADER_PADDING * 2) + (int)gs.MeasureString(TP.Text, Font).Width;
+                    TitleLenght += ((int)(TAB_HEADER_PADDING * ScaleFactor) * 2) + (int)gs.MeasureString(TP.Text, Font).Width;
                 }
             }
 
@@ -474,18 +531,18 @@ namespace ReaLTaiizor.Controls
             {
                 case Alignment.Center:
                     int CenterLocation = (Width / 2) - (TitleLenght / 2);
-                    _tabRects.Add(new Rectangle(CenterLocation, 0, (TAB_HEADER_PADDING * 2) + (int)gs.MeasureString(BaseTabControl.TabPages[0].Text, Font).Width, Height));
+                    _tabRects.Add(new Rectangle(CenterLocation, 0, ((int)(TAB_HEADER_PADDING * ScaleFactor) * 2) + (int)gs.MeasureString(BaseTabControl.TabPages[0].Text, Font).Width, Height));
                     for (int i = 1; i < BaseTabControl.TabPages.Count; i++)
                     {
-                        _tabRects.Add(new Rectangle(_tabRects[i - 1].Right, 0, (TAB_HEADER_PADDING * 2) + (int)gs.MeasureString(BaseTabControl.TabPages[i].Text, Font).Width, Height));
+                        _tabRects.Add(new Rectangle(_tabRects[i - 1].Right, 0, ((int)(TAB_HEADER_PADDING * ScaleFactor) * 2) + (int)gs.MeasureString(BaseTabControl.TabPages[i].Text, Font).Width, Height));
                     }
 
                     break;
                 case Alignment.Right:
-                    _tabRects.Add(new Rectangle(Width - TitleLenght - SkinManager.FORM_PADDING, 0, (TAB_HEADER_PADDING * 2) + (int)gs.MeasureString(BaseTabControl.TabPages[0].Text, Font).Width, Height));
+                    _tabRects.Add(new Rectangle(Width - TitleLenght - SkinManager.FORM_PADDING, 0, ((int)(TAB_HEADER_PADDING * ScaleFactor) * 2) + (int)gs.MeasureString(BaseTabControl.TabPages[0].Text, Font).Width, Height));
                     for (int i = 1; i < BaseTabControl.TabPages.Count; i++)
                     {
-                        _tabRects.Add(new Rectangle(_tabRects[i - 1].Right, 0, (TAB_HEADER_PADDING * 2) + (int)gs.MeasureString(BaseTabControl.TabPages[i].Text, Font).Width, Height));
+                        _tabRects.Add(new Rectangle(_tabRects[i - 1].Right, 0, ((int)(TAB_HEADER_PADDING * ScaleFactor) * 2) + (int)gs.MeasureString(BaseTabControl.TabPages[i].Text, Font).Width, Height));
                     }
 
                     break;
@@ -495,22 +552,22 @@ namespace ReaLTaiizor.Controls
                         Size textSize = TextRenderer.MeasureText(BaseTabControl.TabPages[i].Text, Font);
                         if (TabLabel == TabLabelStyle.Icon)
                         {
-                            textSize.Width = ICON_SIZE;
+                            textSize.Width = (int)(ICON_SIZE * ScaleFactor);
                         }
 
-                        int TabWidth = (TAB_HEADER_PADDING * 2) + textSize.Width;
-                        if (TabWidth > TAB_WIDTH_MAX)
+                        int TabWidth = ((int)(TAB_HEADER_PADDING * ScaleFactor) * 2) + textSize.Width;
+                        if (TabWidth > (int)(TAB_WIDTH_MAX * ScaleFactor))
                         {
-                            TabWidth = TAB_WIDTH_MAX;
+                            TabWidth = (int)(TAB_WIDTH_MAX * ScaleFactor);
                         }
-                        else if (TabWidth < TAB_WIDTH_MIN)
+                        else if (TabWidth < (int)(TAB_WIDTH_MIN * ScaleFactor))
                         {
-                            TabWidth = TAB_WIDTH_MIN;
+                            TabWidth = (int)(TAB_WIDTH_MIN * ScaleFactor);
                         }
 
                         if (i == 0)
                         {
-                            _tabRects.Add(new Rectangle(FIRST_TAB_PADDING - TAB_HEADER_PADDING, 0, TabWidth, Height));
+                            _tabRects.Add(new Rectangle((int)(FIRST_TAB_PADDING * ScaleFactor) - (int)(TAB_HEADER_PADDING * ScaleFactor), 0, TabWidth, Height));
                         }
                         else
                         {

--- a/src/ReaLTaiizor/Controls/TabSelector/MaterialTabSelector.cs
+++ b/src/ReaLTaiizor/Controls/TabSelector/MaterialTabSelector.cs
@@ -154,10 +154,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -170,10 +168,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         [Category("Appearance")]

--- a/src/ReaLTaiizor/Controls/TextBox/MaterialMaskedTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/MaterialMaskedTextBox.cs
@@ -905,10 +905,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -921,10 +919,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public MaterialMaskedTextBox()

--- a/src/ReaLTaiizor/Controls/TextBox/MaterialMaskedTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/MaterialMaskedTextBox.cs
@@ -81,7 +81,7 @@ namespace ReaLTaiizor.Controls
                 field = value;
                 if (field)
                 {
-                    _helperTextHeight = HELPER_TEXT_HEIGHT;
+                    _helperTextHeight = (int)(HELPER_TEXT_HEIGHT * ScaleFactor);
                 }
                 else
                 {
@@ -871,6 +871,7 @@ namespace ReaLTaiizor.Controls
         private const int ACTIVATION_INDICATOR_HEIGHT = 2;
         private const int HELPER_TEXT_HEIGHT = 16;
         private const int FONT_HEIGHT = 20;
+        private const int BASE_TEXTBOX_Y = 22;
 
         private int HEIGHT = 48;
 
@@ -885,13 +886,52 @@ namespace ReaLTaiizor.Controls
         private Rectangle _leadingIconBounds;
         private Rectangle _trailingIconBounds;
 
+        private bool _needsLayoutRefresh = false;
+
         private Dictionary<string, TextureBrush> iconsBrushes;
         private Dictionary<string, TextureBrush> iconsErrorBrushes;
 
         protected readonly MaterialBaseMaskedTextBox baseTextBox;
 
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         public MaterialMaskedTextBox()
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             // Material Properties
             UseAccent = true;
             MouseState = MaterialMouseState.OUT;
@@ -917,7 +957,7 @@ namespace ReaLTaiizor.Controls
                 preProcessIcons();
             };
 
-            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1);
+            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
 
             baseTextBox = new MaterialBaseMaskedTextBox
             {
@@ -925,14 +965,14 @@ namespace ReaLTaiizor.Controls
                 Font = base.Font,
                 ForeColor = SkinManager.TextHighEmphasisColor,
                 Multiline = false,
-                Location = new Point(LEFT_PADDING, (HEIGHT / 2) - (FONT_HEIGHT / 2)),
-                Width = Width - (LEFT_PADDING + RIGHT_PADDING),
-                Height = FONT_HEIGHT
+                Location = new Point((int)(LEFT_PADDING * ScaleFactor), ((int)(HEIGHT * ScaleFactor) / 2) - ((int)(FONT_HEIGHT * ScaleFactor) / 2)),
+                Width = Width - ((int)(LEFT_PADDING * ScaleFactor) + (int)(RIGHT_PADDING * ScaleFactor)),
+                Height = (int)(FONT_HEIGHT * ScaleFactor)
             };
 
             Enabled = true;
             ReadOnly = false;
-            Size = new Size(250, HEIGHT);
+            Size = new Size(250, (int)(HEIGHT * ScaleFactor));
 
             UseTallSize = true;
             PrefixSuffix = PrefixSuffixTypes.None;
@@ -985,8 +1025,20 @@ namespace ReaLTaiizor.Controls
             ResumeLayout(false);
         }
 
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            _needsLayoutRefresh = true;
+        }
+
         protected override void OnPaint(PaintEventArgs pevent)
         {
+            if (_needsLayoutRefresh)
+            {
+                UpdateRects();
+                _needsLayoutRefresh = false;
+            }
+
             Graphics g = pevent.Graphics;
             g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
             g.Clear(Parent.BackColor == Color.Transparent ? ((Parent.Parent == null || (Parent.Parent != null && Parent.Parent.BackColor == Color.Transparent)) ? SkinManager.BackgroundColor : Parent.Parent.BackColor) : Parent.BackColor);
@@ -1033,8 +1085,8 @@ namespace ReaLTaiizor.Controls
 
             // HintText
             bool userTextPresent = !string.IsNullOrEmpty(Text);
-            Rectangle helperTextRect = new(LEFT_PADDING - _prefix_padding, LINE_Y + ACTIVATION_INDICATOR_HEIGHT, Width - (LEFT_PADDING - _prefix_padding) - _right_padding, HELPER_TEXT_HEIGHT);
-            Rectangle hintRect = new(_left_padding - _prefix_padding, HINT_TEXT_SMALL_Y, Width - (_left_padding - _prefix_padding) - _right_padding, HINT_TEXT_SMALL_SIZE);
+            Rectangle helperTextRect = new((int)(LEFT_PADDING * ScaleFactor) - _prefix_padding, LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * ScaleFactor), Width - ((int)(LEFT_PADDING * ScaleFactor) - _prefix_padding) - _right_padding, (int)(HELPER_TEXT_HEIGHT * ScaleFactor));
+            Rectangle hintRect = new(_left_padding - _prefix_padding, (int)(HINT_TEXT_SMALL_Y * ScaleFactor), Width - (_left_padding - _prefix_padding) - _right_padding, (int)(HINT_TEXT_SMALL_SIZE * ScaleFactor));
             int hintTextSize = 12;
 
             // bottom line base
@@ -1077,7 +1129,7 @@ namespace ReaLTaiizor.Controls
                 // Draw Prefix text 
                 NativeText.DrawTransparentText(
                 PrefixSuffixText,
-                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1),
+                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor),
                 Enabled ? SkinManager.TextMediumEmphasisColor : SkinManager.TextDisabledOrHintColor,
                 prefixRect.Location,
                 prefixRect.Size,
@@ -1097,7 +1149,7 @@ namespace ReaLTaiizor.Controls
                 // Draw Suffix text 
                 NativeText.DrawTransparentText(
                 PrefixSuffixText,
-                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1),
+                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor),
                 Enabled ? SkinManager.TextMediumEmphasisColor : SkinManager.TextDisabledOrHintColor,
                 suffixRect.Location,
                 suffixRect.Size,
@@ -1110,7 +1162,7 @@ namespace ReaLTaiizor.Controls
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                 Hint,
-                SkinManager.GetTextBoxFontBySize(hintTextSize),
+                SkinManager.GetTextBoxFontBySize(hintTextSize, ScaleFactor),
                 Enabled ? !_errorState || (!userTextPresent && !isFocused) ? isFocused ? UseAccent ?
                 SkinManager.ColorScheme.AccentColor : // Focus Accent
                 SkinManager.ColorScheme.PrimaryColor : // Focus Primary
@@ -1128,7 +1180,7 @@ namespace ReaLTaiizor.Controls
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                 HelperText,
-                SkinManager.GetTextBoxFontBySize(hintTextSize),
+                SkinManager.GetTextBoxFontBySize(hintTextSize, ScaleFactor),
                 Enabled ? !_errorState || (!userTextPresent && !isFocused) ? isFocused ? UseAccent ?
                 SkinManager.ColorScheme.AccentColor : // Focus Accent
                 SkinManager.ColorScheme.PrimaryColor : // Focus Primary
@@ -1146,7 +1198,7 @@ namespace ReaLTaiizor.Controls
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                 ErrorMessage,
-                SkinManager.GetTextBoxFontBySize(hintTextSize),
+                SkinManager.GetTextBoxFontBySize(hintTextSize, ScaleFactor),
                 Enabled ?
                 SkinManager.BackgroundHoverRedColor : // error state
                 SkinManager.TextDisabledOrHintColor, // Disabled
@@ -1235,15 +1287,25 @@ namespace ReaLTaiizor.Controls
             }
         }
 
+        protected override void OnDpiChangedAfterParent(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            base.OnDpiChangedAfterParent(e);
+        }
+
         protected override void OnResize(EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnResize(e);
 
             UpdateRects();
             preProcessIcons();
 
-            Size = new Size(Width, HEIGHT);
-            LINE_Y = HEIGHT - ACTIVATION_INDICATOR_HEIGHT - _helperTextHeight;
+            Size = new Size(Width, (int)(HEIGHT * ScaleFactor));
+            LINE_Y = (int)(HEIGHT * ScaleFactor) - (int)(ACTIVATION_INDICATOR_HEIGHT * ScaleFactor) - _helperTextHeight;
 
         }
 
@@ -1257,31 +1319,31 @@ namespace ReaLTaiizor.Controls
         }
 
         #region Icon
-        private static Size ResizeIcon(Image Icon)
+        private Size ResizeIcon(Image Icon)
         {
             int newWidth, newHeight;
-            //Resize icon if greater than ICON_SIZE
-            if (Icon.Width > ICON_SIZE || Icon.Height > ICON_SIZE)
+            //Resize icon if greater than (int)(ICON_SIZE * ScaleFactor)
+            if (Icon.Width > (int)(ICON_SIZE * ScaleFactor) || Icon.Height > (int)(ICON_SIZE * ScaleFactor))
             {
                 //calculate aspect ratio
                 float aspect = Icon.Width / (float)Icon.Height;
 
                 //calculate new dimensions based on aspect ratio
-                newWidth = (int)(ICON_SIZE * aspect);
+                newWidth = (int)((int)(ICON_SIZE * ScaleFactor) * aspect);
                 newHeight = (int)(newWidth / aspect);
 
                 //if one of the two dimensions exceed the box dimensions
-                if (newWidth > ICON_SIZE || newHeight > ICON_SIZE)
+                if (newWidth > (int)(ICON_SIZE * ScaleFactor) || newHeight > (int)(ICON_SIZE * ScaleFactor))
                 {
                     //depending on which of the two exceeds the box dimensions set it as the box dimension and calculate the other one based on the aspect ratio
                     if (newWidth > newHeight)
                     {
-                        newWidth = ICON_SIZE;
+                        newWidth = (int)(ICON_SIZE * ScaleFactor);
                         newHeight = (int)(newWidth / aspect);
                     }
                     else
                     {
-                        newHeight = ICON_SIZE;
+                        newHeight = (int)(ICON_SIZE * ScaleFactor);
                         newWidth = (int)(newHeight * aspect);
                     }
                 }
@@ -1339,7 +1401,7 @@ namespace ReaLTaiizor.Controls
             iconsErrorBrushes = new Dictionary<string, TextureBrush>(2);
 
             // Image Rect
-            Rectangle destRect = new(0, 0, ICON_SIZE, ICON_SIZE);
+            Rectangle destRect = new(0, 0, (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
 
             if (LeadingIcon != null)
             {
@@ -1347,7 +1409,7 @@ namespace ReaLTaiizor.Controls
                 // *** _leadingIcon ***
                 // ********************
 
-                //Resize icon if greater than ICON_SIZE
+                //Resize icon if greater than (int)(ICON_SIZE * ScaleFactor)
                 Size newSize_leadingIcon = ResizeIcon(LeadingIcon);
                 Bitmap _leadingIconIconResized = new(LeadingIcon, newSize_leadingIcon.Width, newSize_leadingIcon.Height);
 
@@ -1404,7 +1466,7 @@ namespace ReaLTaiizor.Controls
                 // *** _trailingIcon ***
                 // *********************
 
-                //Resize icon if greater than ICON_SIZE
+                //Resize icon if greater than (int)(ICON_SIZE * ScaleFactor)
                 Size newSize_trailingIcon = ResizeIcon(TrailingIcon);
                 Bitmap _trailingIconResized = new(TrailingIcon, newSize_trailingIcon.Width, newSize_trailingIcon.Height);
 
@@ -1461,33 +1523,33 @@ namespace ReaLTaiizor.Controls
         {
             HEIGHT = UseTallSize ? 48 : 36;
             HEIGHT += _helperTextHeight;
-            Size = new Size(Size.Width, HEIGHT);
+            Size = new Size(Size.Width, (int)(HEIGHT * ScaleFactor));
         }
 
         private void UpdateRects()
         {
             if (LeadingIcon != null)
             {
-                _left_padding = LEFT_PADDING + ICON_SIZE;
+                _left_padding = (int)(LEFT_PADDING * ScaleFactor) + (int)(ICON_SIZE * ScaleFactor);
             }
             else
             {
-                _left_padding = LEFT_PADDING;
+                _left_padding = (int)(LEFT_PADDING * ScaleFactor);
             }
 
             if (TrailingIcon != null)
             {
-                _right_padding = RIGHT_PADDING + ICON_SIZE;
+                _right_padding = (int)(RIGHT_PADDING * ScaleFactor) + (int)(ICON_SIZE * ScaleFactor);
             }
             else
             {
-                _right_padding = RIGHT_PADDING;
+                _right_padding = (int)(RIGHT_PADDING * ScaleFactor);
             }
 
             if (PrefixSuffix == PrefixSuffixTypes.Prefix && PrefixSuffixText != null && PrefixSuffixText.Length > 0)
             {
                 using MaterialNativeTextRenderer NativeText = new(CreateGraphics());
-                _prefix_padding = NativeText.MeasureLogString(PrefixSuffixText, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1)).Width + PREFIX_SUFFIX_PADDING;
+                _prefix_padding = NativeText.MeasureLogString(PrefixSuffixText, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor)).Width + (int)(PREFIX_SUFFIX_PADDING * ScaleFactor);
                 _left_padding += _prefix_padding;
             }
             else
@@ -1498,7 +1560,7 @@ namespace ReaLTaiizor.Controls
             if (PrefixSuffix == PrefixSuffixTypes.Suffix && PrefixSuffixText != null && PrefixSuffixText.Length > 0)
             {
                 using MaterialNativeTextRenderer NativeText = new(CreateGraphics());
-                _suffix_padding = NativeText.MeasureLogString(PrefixSuffixText, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1)).Width + PREFIX_SUFFIX_PADDING;
+                _suffix_padding = NativeText.MeasureLogString(PrefixSuffixText, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor)).Width + (int)(PREFIX_SUFFIX_PADDING * ScaleFactor);
                 _right_padding += _suffix_padding;
             }
             else
@@ -1508,19 +1570,19 @@ namespace ReaLTaiizor.Controls
 
             if (hasHint && UseTallSize && (isFocused || !string.IsNullOrEmpty(Text)))
             {
-                baseTextBox.Location = new Point(_left_padding, 22);
+                baseTextBox.Location = new Point(_left_padding, (int)(BASE_TEXTBOX_Y * ScaleFactor));
                 baseTextBox.Width = Width - (_left_padding + _right_padding);
-                baseTextBox.Height = FONT_HEIGHT;
+                baseTextBox.Height = (int)(FONT_HEIGHT * ScaleFactor);
             }
             else
             {
-                baseTextBox.Location = new Point(_left_padding, ((LINE_Y + ACTIVATION_INDICATOR_HEIGHT) / 2) - (FONT_HEIGHT / 2));
+                baseTextBox.Location = new Point(_left_padding, ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * ScaleFactor)) / 2) - ((int)(FONT_HEIGHT * ScaleFactor) / 2));
                 baseTextBox.Width = Width - (_left_padding + _right_padding);
-                baseTextBox.Height = FONT_HEIGHT;
+                baseTextBox.Height = (int)(FONT_HEIGHT * ScaleFactor);
             }
 
-            _leadingIconBounds = new Rectangle(8, ((LINE_Y + ACTIVATION_INDICATOR_HEIGHT) / 2) - (ICON_SIZE / 2), ICON_SIZE, ICON_SIZE);
-            _trailingIconBounds = new Rectangle(Width - (ICON_SIZE + 8), ((LINE_Y + ACTIVATION_INDICATOR_HEIGHT) / 2) - (ICON_SIZE / 2), ICON_SIZE, ICON_SIZE);
+            _leadingIconBounds = new Rectangle(8, ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * ScaleFactor)) / 2) - ((int)(ICON_SIZE * ScaleFactor) / 2), (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
+            _trailingIconBounds = new Rectangle(Width - ((int)(ICON_SIZE * ScaleFactor) + 8), ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * ScaleFactor)) / 2) - ((int)(ICON_SIZE * ScaleFactor) / 2), (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
         }
 
         public void SetErrorState(bool ErrorState)

--- a/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
@@ -159,7 +159,6 @@ namespace ReaLTaiizor.Controls
         private readonly AnimationManager _animationManager;
         private Dictionary<string, TextureBrush> iconsBrushes;
         private Dictionary<string, TextureBrush> iconsErrorBrushes;
-        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
 
         [Category("Material")]
         [Browsable(true)]
@@ -308,18 +307,6 @@ namespace ReaLTaiizor.Controls
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                // Release handle from CreateFont / LogFont
-                foreach (IntPtr handle in LFontToBeReleased)
-                {
-                    if (handle != IntPtr.Zero)
-                    {
-                        DeleteObject(handle);
-                    }
-                }
-                LFontToBeReleased.Clear();
-            }
             base.Dispose(disposing);
         }
 
@@ -678,7 +665,6 @@ namespace ReaLTaiizor.Controls
                 textSelected = textToDisplay.Substring(SelectionStart, SelectionLength);
 
                 IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
-                LFontToBeReleased.Add(font);
 
                 int selectX = NativeText.MeasureLogString(textBeforeSelection, font).Width;
                 int selectWidth = NativeText.MeasureLogString(textSelected, font).Width;
@@ -711,7 +697,6 @@ namespace ReaLTaiizor.Controls
 
                 // Draw Selected Text
                 IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
-                LFontToBeReleased.Add(font);
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                     textSelected,
@@ -728,7 +713,6 @@ namespace ReaLTaiizor.Controls
             if (hasHint && (UseTallSize || string.IsNullOrEmpty(Text)))
             {
                 IntPtr font = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
-                LFontToBeReleased.Add(font);
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                 Hint,

--- a/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
@@ -140,7 +140,7 @@ namespace ReaLTaiizor.Controls
                 }
             }
         }
-        
+
         private const int ICON_SIZE = 24;
         private const int HINT_TEXT_SMALL_SIZE = 18;
         private const int HINT_TEXT_SMALL_Y = 4;
@@ -715,7 +715,7 @@ namespace ReaLTaiizor.Controls
                 // Draw user text
                 NativeText.DrawTransparentText(
                     textToDisplay,
-                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1,ScaleFactor),
+                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor),
                     Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                     textRect.Location,
                     textRect.Size,

--- a/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
@@ -19,7 +19,7 @@ namespace ReaLTaiizor.Controls
 {
     #region MaterialTextBox
 
-    [ToolboxItem(false), Description("[HYrecv remake: This control have unexpected behavior in Windows DPI scaling env. Replace it with MaterialTextBoxEdit or it may mislead users!] \nThis control has been replaced by MaterialTextBoxEdit"), Obsolete("Use MaterialTextBoxEdit instead", false)]
+    [ToolboxItem(false), Description("[HYrecv remake: This control has unexpected behavior in Windows DPI scaling env. Replace it with MaterialTextBoxEdit or it may mislead users!] \nThis control has been replaced by MaterialTextBoxEdit"), Obsolete("Use MaterialTextBoxEdit instead", false)]
     public class MaterialTextBox : RichTextBox, MaterialControlI
     {
         MaterialContextMenuStrip cms = new MaterialTextBoxContextMenuStrip();

--- a/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
@@ -239,6 +239,9 @@ namespace ReaLTaiizor.Controls
 
         public MaterialTextBox()
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             // Material Properties
             Hint = "";
             Password = false;
@@ -572,8 +575,16 @@ namespace ReaLTaiizor.Controls
             return _errorState;
         }
 
+
+        private bool _hasRefreshed = false;
         protected override void OnPaint(PaintEventArgs pevent)
         {
+            if (!_hasRefreshed)
+            {
+                UpdateRects();
+                Invalidate();
+                _hasRefreshed = true;
+            }
             ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
             ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
 
@@ -810,8 +821,12 @@ namespace ReaLTaiizor.Controls
             Invalidate();
         }
 
+
         protected override void OnResize(EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnResize(e);
             Size = new Size(Width, (int)(HEIGHT * ScaleFactor));
             LINE_Y = (int)(HEIGHT * ScaleFactor) - (int)(BOTTOM_PADDING * ScaleFactor);

--- a/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
@@ -19,7 +19,7 @@ namespace ReaLTaiizor.Controls
 {
     #region MaterialTextBox
 
-    [ToolboxItem(false), Description("This control has been replaced by MaterialTextBoxEdit"), Obsolete("Use MaterialTextBoxEdit instead", false)]
+    [ToolboxItem(false), Description("[HYrecv remake: This control have unexpected behavior in Windows DPI scaling env. Replace it with MaterialTextBoxEdit or it may mislead users!] \nThis control has been replaced by MaterialTextBoxEdit"), Obsolete("Use MaterialTextBoxEdit instead", false)]
     public class MaterialTextBox : RichTextBox, MaterialControlI
     {
         MaterialContextMenuStrip cms = new MaterialTextBoxContextMenuStrip();
@@ -46,7 +46,7 @@ namespace ReaLTaiizor.Controls
             {
                 field = value;
                 HEIGHT = UseTallSize ? 50 : 36;
-                Size = new Size(Size.Width, HEIGHT);
+                Size = new Size(Size.Width, (int)(HEIGHT * GetDeviceScaleFactor()));
                 UpdateRects(false);
                 Invalidate();
             }
@@ -140,7 +140,7 @@ namespace ReaLTaiizor.Controls
                 }
             }
         }
-
+        
         private const int ICON_SIZE = 24;
         private const int HINT_TEXT_SMALL_SIZE = 18;
         private const int HINT_TEXT_SMALL_Y = 4;
@@ -159,6 +159,7 @@ namespace ReaLTaiizor.Controls
         private readonly AnimationManager _animationManager;
         private Dictionary<string, TextureBrush> iconsBrushes;
         private Dictionary<string, TextureBrush> iconsErrorBrushes;
+        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
 
         [Category("Material")]
         [Browsable(true)]
@@ -249,7 +250,7 @@ namespace ReaLTaiizor.Controls
         protected override void OnCreateControl()
         {
             base.OnCreateControl();
-            base.Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1);
+            base.Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
             base.AutoSize = false;
 
             SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.DoubleBuffer | ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint, true);
@@ -261,8 +262,8 @@ namespace ReaLTaiizor.Controls
 
             // Size and padding
             HEIGHT = UseTallSize ? 50 : 36;
-            Size = new Size(Size.Width, HEIGHT);
-            LINE_Y = HEIGHT - BOTTOM_PADDING;
+            Size = new Size(Size.Width, (int)(HEIGHT * GetDeviceScaleFactor()));
+            LINE_Y = (int)(HEIGHT * GetDeviceScaleFactor()) - (int)(BOTTOM_PADDING * GetDeviceScaleFactor());
             UpdateRects();
 
             // events
@@ -302,34 +303,51 @@ namespace ReaLTaiizor.Controls
 
         public override Size GetPreferredSize(Size proposedSize)
         {
-            return new Size(proposedSize.Width, HEIGHT);
+            return new Size(proposedSize.Width, (int)(HEIGHT * GetDeviceScaleFactor()));
         }
 
-        private static Size ResizeIcon(Image Icon)
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Release handle from CreateFont / LogFont
+                foreach (IntPtr handle in LFontToBeReleased)
+                {
+                    if (handle != IntPtr.Zero)
+                    {
+                        DeleteObject(handle);
+                    }
+                }
+                LFontToBeReleased.Clear();
+            }
+            base.Dispose(disposing);
+        }
+
+        private Size ResizeIcon(Image Icon)
         {
             int newWidth, newHeight;
-            //Resize icon if greater than ICON_SIZE
-            if (Icon.Width > ICON_SIZE || Icon.Height > ICON_SIZE)
+            //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
+            if (Icon.Width > (int)(ICON_SIZE * GetDeviceScaleFactor()) || Icon.Height > (int)(ICON_SIZE * GetDeviceScaleFactor()))
             {
                 //calculate aspect ratio
                 float aspect = Icon.Width / (float)Icon.Height;
 
                 //calculate new dimensions based on aspect ratio
-                newWidth = (int)(ICON_SIZE * aspect);
+                newWidth = (int)((int)(ICON_SIZE * GetDeviceScaleFactor()) * aspect);
                 newHeight = (int)(newWidth / aspect);
 
                 //if one of the two dimensions exceed the box dimensions
-                if (newWidth > ICON_SIZE || newHeight > ICON_SIZE)
+                if (newWidth > (int)(ICON_SIZE * GetDeviceScaleFactor()) || newHeight > (int)(ICON_SIZE * GetDeviceScaleFactor()))
                 {
                     //depending on which of the two exceeds the box dimensions set it as the box dimension and calculate the other one based on the aspect ratio
                     if (newWidth > newHeight)
                     {
-                        newWidth = ICON_SIZE;
+                        newWidth = (int)(ICON_SIZE * GetDeviceScaleFactor());
                         newHeight = (int)(newWidth / aspect);
                     }
                     else
                     {
-                        newHeight = ICON_SIZE;
+                        newHeight = (int)(ICON_SIZE * GetDeviceScaleFactor());
                         newWidth = (int)(newHeight * aspect);
                     }
                 }
@@ -387,7 +405,7 @@ namespace ReaLTaiizor.Controls
             iconsErrorBrushes = new Dictionary<string, TextureBrush>(2);
 
             // Image Rect
-            Rectangle destRect = new(0, 0, ICON_SIZE, ICON_SIZE);
+            Rectangle destRect = new(0, 0, (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
 
             if (LeadingIcon != null)
             {
@@ -395,7 +413,7 @@ namespace ReaLTaiizor.Controls
                 // *** _leadingIcon ***
                 // ********************
 
-                //Resize icon if greater than ICON_SIZE
+                //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
                 Size newSize_leadingIcon = ResizeIcon(LeadingIcon);
                 Bitmap _leadingIconIconResized = new(LeadingIcon, newSize_leadingIcon.Width, newSize_leadingIcon.Height);
 
@@ -433,7 +451,7 @@ namespace ReaLTaiizor.Controls
                 // *** _trailingIcon ***
                 // *********************
 
-                //Resize icon if greater than ICON_SIZE
+                //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
                 Size newSize_trailingIcon = ResizeIcon(TrailingIcon);
                 Bitmap _trailingIconResized = new(TrailingIcon, newSize_trailingIcon.Width, newSize_trailingIcon.Height);
 
@@ -489,7 +507,7 @@ namespace ReaLTaiizor.Controls
         {
             if (LeadingIcon != null)
             {
-                _left_padding = SkinManager.FORM_PADDING + ICON_SIZE;
+                _left_padding = SkinManager.FORM_PADDING + (int)(ICON_SIZE * GetDeviceScaleFactor());
             }
             else
             {
@@ -498,21 +516,21 @@ namespace ReaLTaiizor.Controls
 
             if (TrailingIcon != null)
             {
-                _right_padding = SkinManager.FORM_PADDING + ICON_SIZE;
+                _right_padding = SkinManager.FORM_PADDING + (int)(ICON_SIZE * GetDeviceScaleFactor());
             }
             else
             {
                 _right_padding = SkinManager.FORM_PADDING;
             }
 
-            _leadingIconBounds = new Rectangle(8, (HEIGHT / 2) - (ICON_SIZE / 2), ICON_SIZE, ICON_SIZE);
-            _trailingIconBounds = new Rectangle(Width - (ICON_SIZE + 8), (HEIGHT / 2) - (ICON_SIZE / 2), ICON_SIZE, ICON_SIZE);
+            _leadingIconBounds = new Rectangle(8, ((int)(HEIGHT * GetDeviceScaleFactor()) / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
+            _trailingIconBounds = new Rectangle(Width - ((int)(ICON_SIZE * GetDeviceScaleFactor()) + 8), ((int)(HEIGHT * GetDeviceScaleFactor()) / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
             _textfieldBounds = new Rectangle(_left_padding, ClientRectangle.Y, Width - _left_padding - _right_padding, LINE_Y);
 
             if (RedefineTextField)
             {
                 Rectangle rect = new(_left_padding, UseTallSize ? hasHint ?
-        (HINT_TEXT_SMALL_Y + HINT_TEXT_SMALL_SIZE) : // Has hint and it's tall
+        ((int)(HINT_TEXT_SMALL_Y * GetDeviceScaleFactor()) + (int)(HINT_TEXT_SMALL_SIZE * GetDeviceScaleFactor())) : // Has hint and it's tall
         (int)(LINE_Y / 3.5) : // No hint and tall
         Height / 5, // not tall
         ClientSize.Width - _left_padding - _right_padding, LINE_Y);
@@ -521,6 +539,22 @@ namespace ReaLTaiizor.Controls
             }
 
         }
+
+        private float GetDeviceScaleFactor()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)this.DeviceDpi / 96f;
+            return scalingFactor;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
+        }
+
 
         public void SetErrorState(bool ErrorState)
         {
@@ -589,7 +623,7 @@ namespace ReaLTaiizor.Controls
                     if (hasHint && UseTallSize && (Focused || userTextPresent))
                     {
                         // hint text
-                        hintRect = new Rectangle(_left_padding, HINT_TEXT_SMALL_Y, Width - _left_padding - _right_padding, HINT_TEXT_SMALL_SIZE);
+                        hintRect = new Rectangle(_left_padding, (int)(HINT_TEXT_SMALL_Y * GetDeviceScaleFactor()), Width - _left_padding - _right_padding, (int)(HINT_TEXT_SMALL_SIZE * GetDeviceScaleFactor()));
                         hintTextSize = 12;
                     }
 
@@ -609,9 +643,9 @@ namespace ReaLTaiizor.Controls
                     {
                         hintRect = new Rectangle(
                             _left_padding,
-                            userTextPresent ? HINT_TEXT_SMALL_Y : ClientRectangle.Y + (int)((HINT_TEXT_SMALL_Y - ClientRectangle.Y) * animationProgress),
+                            userTextPresent ? (int)(HINT_TEXT_SMALL_Y * GetDeviceScaleFactor()) : ClientRectangle.Y + (int)(((int)(HINT_TEXT_SMALL_Y * GetDeviceScaleFactor()) - ClientRectangle.Y) * animationProgress),
                             Width - _left_padding - _right_padding,
-                            userTextPresent ? HINT_TEXT_SMALL_SIZE : (int)(LINE_Y + ((HINT_TEXT_SMALL_SIZE - LINE_Y) * animationProgress)));
+                            userTextPresent ? (int)(HINT_TEXT_SMALL_SIZE * GetDeviceScaleFactor()) : (int)(LINE_Y + (((int)(HINT_TEXT_SMALL_SIZE * GetDeviceScaleFactor()) - LINE_Y) * animationProgress)));
                         hintTextSize = userTextPresent ? 12 : (int)(16 + ((12 - 16) * animationProgress));
                     }
 
@@ -643,24 +677,27 @@ namespace ReaLTaiizor.Controls
                 string textBeforeSelection = textToDisplay.Substring(0, SelectionStart);
                 textSelected = textToDisplay.Substring(SelectionStart, SelectionLength);
 
-                int selectX = NativeText.MeasureLogString(textBeforeSelection, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1)).Width;
-                int selectWidth = NativeText.MeasureLogString(textSelected, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1)).Width;
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                LFontToBeReleased.Add(font);
+
+                int selectX = NativeText.MeasureLogString(textBeforeSelection, font).Width;
+                int selectWidth = NativeText.MeasureLogString(textSelected, font).Width;
 
                 textSelectRect = new Rectangle(
                     textRect.X + selectX, UseTallSize ? hasHint ?
-                     textRect.Y + BOTTOM_PADDING : // tall and hint
-                     (LINE_Y / 3) - BOTTOM_PADDING : // tall and no hint
-                     BOTTOM_PADDING, // not tall
+                     textRect.Y + (int)(BOTTOM_PADDING * GetDeviceScaleFactor()) : // tall and hint
+                     (LINE_Y / 3) - (int)(BOTTOM_PADDING * GetDeviceScaleFactor()) : // tall and no hint
+                     (int)(BOTTOM_PADDING * GetDeviceScaleFactor()), // not tall
                     selectWidth,
                     UseTallSize ? hasHint ?
-                    textRect.Height - (BOTTOM_PADDING * 2) : // tall and hint
+                    textRect.Height - ((int)(BOTTOM_PADDING * GetDeviceScaleFactor()) * 2) : // tall and hint
                     (int)(LINE_Y / 2) : // tall and no hint
-                    LINE_Y - (BOTTOM_PADDING * 2)); // not tall
+                    LINE_Y - ((int)(BOTTOM_PADDING * GetDeviceScaleFactor()) * 2)); // not tall
 
                 // Draw user text
                 NativeText.DrawTransparentText(
                     textToDisplay,
-                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1),
+                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1,GetDeviceScaleFactor()),
                     Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                     textRect.Location,
                     textRect.Size,
@@ -673,10 +710,12 @@ namespace ReaLTaiizor.Controls
                 g.FillRectangle(UseAccent ? SkinManager.ColorScheme.AccentBrush : SkinManager.ColorScheme.DarkPrimaryBrush, textSelectRect);
 
                 // Draw Selected Text
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                LFontToBeReleased.Add(font);
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                     textSelected,
-                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1),
+                    font,
                     SkinManager.ColorScheme.TextColor,
                     textSelectRect.Location,
                     textSelectRect.Size,
@@ -688,10 +727,12 @@ namespace ReaLTaiizor.Controls
             // Draw hint text
             if (hasHint && (UseTallSize || string.IsNullOrEmpty(Text)))
             {
+                IntPtr font = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
+                LFontToBeReleased.Add(font);
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                 Hint,
-                SkinManager.GetTextBoxFontBySize(hintTextSize),
+                font,
                 Enabled ? !_errorState || (!userTextPresent && !Focused) ? Focused ? UseAccent ?
                 SkinManager.ColorScheme.AccentColor : // Focus Accent
                 SkinManager.ColorScheme.PrimaryColor : // Focus Primary
@@ -767,8 +808,8 @@ namespace ReaLTaiizor.Controls
         protected override void OnResize(EventArgs e)
         {
             base.OnResize(e);
-            Size = new Size(Width, HEIGHT);
-            LINE_Y = HEIGHT - BOTTOM_PADDING;
+            Size = new Size(Width, (int)(HEIGHT * GetDeviceScaleFactor()));
+            LINE_Y = (int)(HEIGHT * GetDeviceScaleFactor()) - (int)(BOTTOM_PADDING * GetDeviceScaleFactor());
             UpdateRects(false);
             preProcessIcons();
 
@@ -853,6 +894,9 @@ namespace ReaLTaiizor.Controls
 
         [DllImport(@"User32.dll", EntryPoint = @"SendMessage", CharSet = CharSet.Auto)]
         private static extern int SendMessageRefRect(IntPtr hWnd, uint msg, int wParam, ref RECT rect);
+
+        [DllImport("gdi32.dll", ExactSpelling = true)]
+        private static extern bool DeleteObject(IntPtr hObject);
 
         [StructLayout(LayoutKind.Sequential)]
         private struct RECT

--- a/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
@@ -585,8 +585,8 @@ namespace ReaLTaiizor.Controls
                 Invalidate();
                 _hasRefreshed = true;
             }
-            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            // ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            // ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
 
             base.OnPaint(pevent);
 

--- a/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
@@ -46,7 +46,7 @@ namespace ReaLTaiizor.Controls
             {
                 field = value;
                 HEIGHT = UseTallSize ? 50 : 36;
-                Size = new Size(Size.Width, (int)(HEIGHT * GetDeviceScaleFactor()));
+                Size = new Size(Size.Width, (int)(HEIGHT * ScaleFactor));
                 UpdateRects(false);
                 Invalidate();
             }
@@ -160,6 +160,40 @@ namespace ReaLTaiizor.Controls
         private Dictionary<string, TextureBrush> iconsBrushes;
         private Dictionary<string, TextureBrush> iconsErrorBrushes;
 
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         [Category("Material")]
         [Browsable(true)]
         public bool AnimateReadOnly
@@ -249,7 +283,7 @@ namespace ReaLTaiizor.Controls
         protected override void OnCreateControl()
         {
             base.OnCreateControl();
-            base.Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+            base.Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
             base.AutoSize = false;
 
             SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.DoubleBuffer | ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint, true);
@@ -261,8 +295,8 @@ namespace ReaLTaiizor.Controls
 
             // Size and padding
             HEIGHT = UseTallSize ? 50 : 36;
-            Size = new Size(Size.Width, (int)(HEIGHT * GetDeviceScaleFactor()));
-            LINE_Y = (int)(HEIGHT * GetDeviceScaleFactor()) - (int)(BOTTOM_PADDING * GetDeviceScaleFactor());
+            Size = new Size(Size.Width, (int)(HEIGHT * ScaleFactor));
+            LINE_Y = (int)(HEIGHT * ScaleFactor) - (int)(BOTTOM_PADDING * ScaleFactor);
             UpdateRects();
 
             // events
@@ -302,7 +336,7 @@ namespace ReaLTaiizor.Controls
 
         public override Size GetPreferredSize(Size proposedSize)
         {
-            return new Size(proposedSize.Width, (int)(HEIGHT * GetDeviceScaleFactor()));
+            return new Size(proposedSize.Width, (int)(HEIGHT * ScaleFactor));
         }
 
         protected override void Dispose(bool disposing)
@@ -313,28 +347,28 @@ namespace ReaLTaiizor.Controls
         private Size ResizeIcon(Image Icon)
         {
             int newWidth, newHeight;
-            //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
-            if (Icon.Width > (int)(ICON_SIZE * GetDeviceScaleFactor()) || Icon.Height > (int)(ICON_SIZE * GetDeviceScaleFactor()))
+            //Resize icon if greater than (int)(ICON_SIZE * ScaleFactor)
+            if (Icon.Width > (int)(ICON_SIZE * ScaleFactor) || Icon.Height > (int)(ICON_SIZE * ScaleFactor))
             {
                 //calculate aspect ratio
                 float aspect = Icon.Width / (float)Icon.Height;
 
                 //calculate new dimensions based on aspect ratio
-                newWidth = (int)((int)(ICON_SIZE * GetDeviceScaleFactor()) * aspect);
+                newWidth = (int)((int)(ICON_SIZE * ScaleFactor) * aspect);
                 newHeight = (int)(newWidth / aspect);
 
                 //if one of the two dimensions exceed the box dimensions
-                if (newWidth > (int)(ICON_SIZE * GetDeviceScaleFactor()) || newHeight > (int)(ICON_SIZE * GetDeviceScaleFactor()))
+                if (newWidth > (int)(ICON_SIZE * ScaleFactor) || newHeight > (int)(ICON_SIZE * ScaleFactor))
                 {
                     //depending on which of the two exceeds the box dimensions set it as the box dimension and calculate the other one based on the aspect ratio
                     if (newWidth > newHeight)
                     {
-                        newWidth = (int)(ICON_SIZE * GetDeviceScaleFactor());
+                        newWidth = (int)(ICON_SIZE * ScaleFactor);
                         newHeight = (int)(newWidth / aspect);
                     }
                     else
                     {
-                        newHeight = (int)(ICON_SIZE * GetDeviceScaleFactor());
+                        newHeight = (int)(ICON_SIZE * ScaleFactor);
                         newWidth = (int)(newHeight * aspect);
                     }
                 }
@@ -392,7 +426,7 @@ namespace ReaLTaiizor.Controls
             iconsErrorBrushes = new Dictionary<string, TextureBrush>(2);
 
             // Image Rect
-            Rectangle destRect = new(0, 0, (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
+            Rectangle destRect = new(0, 0, (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
 
             if (LeadingIcon != null)
             {
@@ -400,7 +434,7 @@ namespace ReaLTaiizor.Controls
                 // *** _leadingIcon ***
                 // ********************
 
-                //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
+                //Resize icon if greater than (int)(ICON_SIZE * ScaleFactor)
                 Size newSize_leadingIcon = ResizeIcon(LeadingIcon);
                 Bitmap _leadingIconIconResized = new(LeadingIcon, newSize_leadingIcon.Width, newSize_leadingIcon.Height);
 
@@ -438,7 +472,7 @@ namespace ReaLTaiizor.Controls
                 // *** _trailingIcon ***
                 // *********************
 
-                //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
+                //Resize icon if greater than (int)(ICON_SIZE * ScaleFactor)
                 Size newSize_trailingIcon = ResizeIcon(TrailingIcon);
                 Bitmap _trailingIconResized = new(TrailingIcon, newSize_trailingIcon.Width, newSize_trailingIcon.Height);
 
@@ -494,7 +528,7 @@ namespace ReaLTaiizor.Controls
         {
             if (LeadingIcon != null)
             {
-                _left_padding = SkinManager.FORM_PADDING + (int)(ICON_SIZE * GetDeviceScaleFactor());
+                _left_padding = SkinManager.FORM_PADDING + (int)(ICON_SIZE * ScaleFactor);
             }
             else
             {
@@ -503,21 +537,21 @@ namespace ReaLTaiizor.Controls
 
             if (TrailingIcon != null)
             {
-                _right_padding = SkinManager.FORM_PADDING + (int)(ICON_SIZE * GetDeviceScaleFactor());
+                _right_padding = SkinManager.FORM_PADDING + (int)(ICON_SIZE * ScaleFactor);
             }
             else
             {
                 _right_padding = SkinManager.FORM_PADDING;
             }
 
-            _leadingIconBounds = new Rectangle(8, ((int)(HEIGHT * GetDeviceScaleFactor()) / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
-            _trailingIconBounds = new Rectangle(Width - ((int)(ICON_SIZE * GetDeviceScaleFactor()) + 8), ((int)(HEIGHT * GetDeviceScaleFactor()) / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
+            _leadingIconBounds = new Rectangle(8, ((int)(HEIGHT * ScaleFactor) / 2) - ((int)(ICON_SIZE * ScaleFactor) / 2), (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
+            _trailingIconBounds = new Rectangle(Width - ((int)(ICON_SIZE * ScaleFactor) + 8), ((int)(HEIGHT * ScaleFactor) / 2) - ((int)(ICON_SIZE * ScaleFactor) / 2), (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
             _textfieldBounds = new Rectangle(_left_padding, ClientRectangle.Y, Width - _left_padding - _right_padding, LINE_Y);
 
             if (RedefineTextField)
             {
                 Rectangle rect = new(_left_padding, UseTallSize ? hasHint ?
-        ((int)(HINT_TEXT_SMALL_Y * GetDeviceScaleFactor()) + (int)(HINT_TEXT_SMALL_SIZE * GetDeviceScaleFactor())) : // Has hint and it's tall
+        ((int)(HINT_TEXT_SMALL_Y * ScaleFactor) + (int)(HINT_TEXT_SMALL_SIZE * ScaleFactor)) : // Has hint and it's tall
         (int)(LINE_Y / 3.5) : // No hint and tall
         Height / 5, // not tall
         ClientSize.Width - _left_padding - _right_padding, LINE_Y);
@@ -526,22 +560,6 @@ namespace ReaLTaiizor.Controls
             }
 
         }
-
-        private float GetDeviceScaleFactor()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)this.DeviceDpi / 96f;
-            return scalingFactor;
-        }
-
-        private float GetDeviceScaleFactorSqrt()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            return scalingFactor;
-        }
-
 
         public void SetErrorState(bool ErrorState)
         {
@@ -556,6 +574,9 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs pevent)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             base.OnPaint(pevent);
 
             Graphics g = pevent.Graphics;
@@ -610,7 +631,7 @@ namespace ReaLTaiizor.Controls
                     if (hasHint && UseTallSize && (Focused || userTextPresent))
                     {
                         // hint text
-                        hintRect = new Rectangle(_left_padding, (int)(HINT_TEXT_SMALL_Y * GetDeviceScaleFactor()), Width - _left_padding - _right_padding, (int)(HINT_TEXT_SMALL_SIZE * GetDeviceScaleFactor()));
+                        hintRect = new Rectangle(_left_padding, (int)(HINT_TEXT_SMALL_Y * ScaleFactor), Width - _left_padding - _right_padding, (int)(HINT_TEXT_SMALL_SIZE * ScaleFactor));
                         hintTextSize = 12;
                     }
 
@@ -630,9 +651,9 @@ namespace ReaLTaiizor.Controls
                     {
                         hintRect = new Rectangle(
                             _left_padding,
-                            userTextPresent ? (int)(HINT_TEXT_SMALL_Y * GetDeviceScaleFactor()) : ClientRectangle.Y + (int)(((int)(HINT_TEXT_SMALL_Y * GetDeviceScaleFactor()) - ClientRectangle.Y) * animationProgress),
+                            userTextPresent ? (int)(HINT_TEXT_SMALL_Y * ScaleFactor) : ClientRectangle.Y + (int)(((int)(HINT_TEXT_SMALL_Y * ScaleFactor) - ClientRectangle.Y) * animationProgress),
                             Width - _left_padding - _right_padding,
-                            userTextPresent ? (int)(HINT_TEXT_SMALL_SIZE * GetDeviceScaleFactor()) : (int)(LINE_Y + (((int)(HINT_TEXT_SMALL_SIZE * GetDeviceScaleFactor()) - LINE_Y) * animationProgress)));
+                            userTextPresent ? (int)(HINT_TEXT_SMALL_SIZE * ScaleFactor) : (int)(LINE_Y + (((int)(HINT_TEXT_SMALL_SIZE * ScaleFactor) - LINE_Y) * animationProgress)));
                         hintTextSize = userTextPresent ? 12 : (int)(16 + ((12 - 16) * animationProgress));
                     }
 
@@ -664,26 +685,26 @@ namespace ReaLTaiizor.Controls
                 string textBeforeSelection = textToDisplay.Substring(0, SelectionStart);
                 textSelected = textToDisplay.Substring(SelectionStart, SelectionLength);
 
-                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
 
                 int selectX = NativeText.MeasureLogString(textBeforeSelection, font).Width;
                 int selectWidth = NativeText.MeasureLogString(textSelected, font).Width;
 
                 textSelectRect = new Rectangle(
                     textRect.X + selectX, UseTallSize ? hasHint ?
-                     textRect.Y + (int)(BOTTOM_PADDING * GetDeviceScaleFactor()) : // tall and hint
-                     (LINE_Y / 3) - (int)(BOTTOM_PADDING * GetDeviceScaleFactor()) : // tall and no hint
-                     (int)(BOTTOM_PADDING * GetDeviceScaleFactor()), // not tall
+                     textRect.Y + (int)(BOTTOM_PADDING * ScaleFactor) : // tall and hint
+                     (LINE_Y / 3) - (int)(BOTTOM_PADDING * ScaleFactor) : // tall and no hint
+                     (int)(BOTTOM_PADDING * ScaleFactor), // not tall
                     selectWidth,
                     UseTallSize ? hasHint ?
-                    textRect.Height - ((int)(BOTTOM_PADDING * GetDeviceScaleFactor()) * 2) : // tall and hint
+                    textRect.Height - ((int)(BOTTOM_PADDING * ScaleFactor) * 2) : // tall and hint
                     (int)(LINE_Y / 2) : // tall and no hint
-                    LINE_Y - ((int)(BOTTOM_PADDING * GetDeviceScaleFactor()) * 2)); // not tall
+                    LINE_Y - ((int)(BOTTOM_PADDING * ScaleFactor) * 2)); // not tall
 
                 // Draw user text
                 NativeText.DrawTransparentText(
                     textToDisplay,
-                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1,GetDeviceScaleFactor()),
+                    SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1,ScaleFactor),
                     Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
                     textRect.Location,
                     textRect.Size,
@@ -696,7 +717,7 @@ namespace ReaLTaiizor.Controls
                 g.FillRectangle(UseAccent ? SkinManager.ColorScheme.AccentBrush : SkinManager.ColorScheme.DarkPrimaryBrush, textSelectRect);
 
                 // Draw Selected Text
-                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                     textSelected,
@@ -712,7 +733,7 @@ namespace ReaLTaiizor.Controls
             // Draw hint text
             if (hasHint && (UseTallSize || string.IsNullOrEmpty(Text)))
             {
-                IntPtr font = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
+                IntPtr font = SkinManager.GetTextBoxFontBySize(hintTextSize, ScaleFactor);
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                 Hint,
@@ -792,8 +813,8 @@ namespace ReaLTaiizor.Controls
         protected override void OnResize(EventArgs e)
         {
             base.OnResize(e);
-            Size = new Size(Width, (int)(HEIGHT * GetDeviceScaleFactor()));
-            LINE_Y = (int)(HEIGHT * GetDeviceScaleFactor()) - (int)(BOTTOM_PADDING * GetDeviceScaleFactor());
+            Size = new Size(Width, (int)(HEIGHT * ScaleFactor));
+            LINE_Y = (int)(HEIGHT * ScaleFactor) - (int)(BOTTOM_PADDING * ScaleFactor);
             UpdateRects(false);
             preProcessIcons();
 
@@ -878,9 +899,6 @@ namespace ReaLTaiizor.Controls
 
         [DllImport(@"User32.dll", EntryPoint = @"SendMessage", CharSet = CharSet.Auto)]
         private static extern int SendMessageRefRect(IntPtr hWnd, uint msg, int wParam, ref RECT rect);
-
-        [DllImport("gdi32.dll", ExactSpelling = true)]
-        private static extern bool DeleteObject(IntPtr hObject);
 
         [StructLayout(LayoutKind.Sequential)]
         private struct RECT

--- a/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
+++ b/src/ReaLTaiizor/Controls/TextBox/MaterialTextBox.cs
@@ -172,10 +172,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -188,10 +186,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         [Category("Material")]

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
@@ -690,7 +690,14 @@ namespace ReaLTaiizor.Controls
         private readonly int SB_LINEUP = 0;
         private readonly int SB_LINEDOWN = 1;
         private readonly uint WM_VSCROLL = 277;
+        private const int ACTIVATION_INDICATOR_HEIGHT = 2;
+        private const int FONT_HEIGHT = 20;
         private readonly IntPtr ptrLparam = new(0);
+
+        private bool _needsLayoutRefresh = false;
+
+        private int _left_padding;
+        private int _right_padding;
 
         protected readonly MaterialBaseTextBox baseTextBox;
 
@@ -726,6 +733,17 @@ namespace ReaLTaiizor.Controls
             {
                 _scaleRatioSqrt = value;
             }
+        }
+
+        public void UpdateRects()
+        {
+            _left_padding = (int)(LEFT_PADDING * ScaleFactor);
+            _right_padding = (int)(RIGHT_PADDING * ScaleFactor);
+
+            baseTextBox.Location = new Point(_left_padding, (int)(TOP_PADDING * ScaleFactor));
+            baseTextBox.Width = Width - (_left_padding + _right_padding);
+            baseTextBox.Height = ClientRectangle.Height - (int)(TOP_PADDING * ScaleFactor) - (int)(BOTTOM_PADDING * ScaleFactor);
+            // baseTextBox.Height = (int)(FONT_HEIGHT * ScaleFactor);
         }
 
         public MaterialMultiLineTextBoxEdit()
@@ -776,11 +794,13 @@ namespace ReaLTaiizor.Controls
                 {
                     base.Focus();
                 }
+                UpdateRects();
             };
             baseTextBox.LostFocus += (sender, args) =>
             {
                 isFocused = false;
                 _animationManager.StartNewAnimation(AnimationDirection.Out);
+                UpdateRects();
             };
 
             baseTextBox.TextChanged += new EventHandler(Redraw);
@@ -805,10 +825,22 @@ namespace ReaLTaiizor.Controls
             ResumeLayout(false);
         }
 
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            _needsLayoutRefresh = true;
+        }
+
+
         protected override void OnPaint(PaintEventArgs pevent)
         {
             ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
             ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            if (_needsLayoutRefresh)
+            {
+                UpdateRects();
+                _needsLayoutRefresh = false;
+            }
 
             Graphics g = pevent.Graphics;
             g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
@@ -834,8 +834,8 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs pevent)
         {
-            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            // ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            // ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
             if (_needsLayoutRefresh)
             {
                 UpdateRects();

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
@@ -693,6 +693,41 @@ namespace ReaLTaiizor.Controls
         private readonly IntPtr ptrLparam = new(0);
 
         protected readonly MaterialBaseTextBox baseTextBox;
+
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         public MaterialMultiLineTextBoxEdit()
         {
             AllowScroll = true;
@@ -714,7 +749,7 @@ namespace ReaLTaiizor.Controls
             baseTextBox = new MaterialBaseTextBox
             {
                 BorderStyle = BorderStyle.None,
-                Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor()),
+                Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor),
                 ForeColor = SkinManager.TextHighEmphasisColor,
                 Multiline = true
             };
@@ -762,28 +797,19 @@ namespace ReaLTaiizor.Controls
 
         private void Redraw(object sencer, EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             SuspendLayout();
             Invalidate();
             ResumeLayout(false);
         }
 
-        private float GetDeviceScaleFactor()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)this.DeviceDpi / 96f;
-            return scalingFactor;
-        }
-
-        private float GetDeviceScaleFactorSqrt()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            return scalingFactor;
-        }
-
         protected override void OnPaint(PaintEventArgs pevent)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             Graphics g = pevent.Graphics;
             g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
             g.Clear(Parent.BackColor == Color.Transparent ? ((Parent.Parent == null || (Parent.Parent != null && Parent.Parent.BackColor == Color.Transparent)) ? SkinManager.BackgroundColor : Parent.Parent.BackColor) : Parent.BackColor);
@@ -917,11 +943,11 @@ namespace ReaLTaiizor.Controls
         {
             base.OnResize(e);
 
-            baseTextBox.Location = new Point((int)(LEFT_PADDING * GetDeviceScaleFactor()), (int)(TOP_PADDING * GetDeviceScaleFactor()));
-            baseTextBox.Width = Width - ((int)(LEFT_PADDING * GetDeviceScaleFactor()) + (int)(RIGHT_PADDING * GetDeviceScaleFactor()));
-            baseTextBox.Height = Height - ((int)(TOP_PADDING * GetDeviceScaleFactor()) + (int)(BOTTOM_PADDING * GetDeviceScaleFactor()));
+            baseTextBox.Location = new Point((int)(LEFT_PADDING * ScaleFactor), (int)(TOP_PADDING * ScaleFactor));
+            baseTextBox.Width = Width - ((int)(LEFT_PADDING * ScaleFactor) + (int)(RIGHT_PADDING * ScaleFactor));
+            baseTextBox.Height = Height - ((int)(TOP_PADDING * ScaleFactor) + (int)(BOTTOM_PADDING * ScaleFactor));
 
-            LINE_Y = Height - (int)(LINE_BOTTOM_PADDING * GetDeviceScaleFactor());
+            LINE_Y = Height - (int)(LINE_BOTTOM_PADDING * ScaleFactor);
 
         }
 
@@ -980,9 +1006,6 @@ namespace ReaLTaiizor.Controls
                 SendKeys.Send("{TAB}");
             }
         }
-
-        [DllImport("gdi32.dll", ExactSpelling = true)]
-        private static extern bool DeleteObject(IntPtr hObject);
 
     }
 

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
@@ -114,18 +114,6 @@ namespace ReaLTaiizor.Controls
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                // Release handle from CreateFont / LogFont
-                foreach (IntPtr handle in LFontToBeReleased)
-                {
-                    if (handle != IntPtr.Zero)
-                    {
-                        DeleteObject(handle);
-                    }
-                }
-                LFontToBeReleased.Clear();
-            }
             base.Dispose(disposing);
         }
 
@@ -703,7 +691,6 @@ namespace ReaLTaiizor.Controls
         private readonly int SB_LINEDOWN = 1;
         private readonly uint WM_VSCROLL = 277;
         private readonly IntPtr ptrLparam = new(0);
-        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
 
         protected readonly MaterialBaseTextBox baseTextBox;
         public MaterialMultiLineTextBoxEdit()

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
@@ -712,10 +712,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -728,10 +726,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public void UpdateRects()

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
@@ -4,6 +4,7 @@ using ReaLTaiizor.Child.Material;
 using ReaLTaiizor.Helper;
 using ReaLTaiizor.Manager;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
@@ -30,7 +31,7 @@ namespace ReaLTaiizor.Controls
         [Browsable(false)]
         public MaterialSkinManager SkinManager => MaterialSkinManager.Instance;
 
-        public bool Focus()
+        public new bool Focus()
         {
             return baseTextBox.Focus();
         }
@@ -110,6 +111,23 @@ namespace ReaLTaiizor.Controls
         public override Color BackColor => Parent == null ? SkinManager.BackgroundColor : Parent.BackColor;
 
         public override string Text { get => baseTextBox.Text; set => baseTextBox.Text = value; }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Release handle from CreateFont / LogFont
+                foreach (IntPtr handle in LFontToBeReleased)
+                {
+                    if (handle != IntPtr.Zero)
+                    {
+                        DeleteObject(handle);
+                    }
+                }
+                LFontToBeReleased.Clear();
+            }
+            base.Dispose(disposing);
+        }
 
         [Category("Appearance")]
         public HorizontalAlignment TextAlign { get => baseTextBox.TextAlign; set => baseTextBox.TextAlign = value; }
@@ -670,7 +688,7 @@ namespace ReaLTaiizor.Controls
 
         //private readonly AnimationManager animationManager;
         private readonly AnimationManager _animationManager;
-
+        //
         public bool isFocused = false;
         private const int HINT_TEXT_SMALL_SIZE = 18;
         private const int HINT_TEXT_SMALL_Y = 4;
@@ -685,6 +703,7 @@ namespace ReaLTaiizor.Controls
         private readonly int SB_LINEDOWN = 1;
         private readonly uint WM_VSCROLL = 277;
         private readonly IntPtr ptrLparam = new(0);
+        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
 
         protected readonly MaterialBaseTextBox baseTextBox;
         public MaterialMultiLineTextBoxEdit()
@@ -708,7 +727,7 @@ namespace ReaLTaiizor.Controls
             baseTextBox = new MaterialBaseTextBox
             {
                 BorderStyle = BorderStyle.None,
-                Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1),
+                Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor()),
                 ForeColor = SkinManager.TextHighEmphasisColor,
                 Multiline = true
             };
@@ -759,6 +778,21 @@ namespace ReaLTaiizor.Controls
             SuspendLayout();
             Invalidate();
             ResumeLayout(false);
+        }
+
+        private float GetDeviceScaleFactor()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)this.DeviceDpi / 96f;
+            return scalingFactor;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
         }
 
         protected override void OnPaint(PaintEventArgs pevent)
@@ -896,11 +930,11 @@ namespace ReaLTaiizor.Controls
         {
             base.OnResize(e);
 
-            baseTextBox.Location = new Point(LEFT_PADDING, TOP_PADDING);
-            baseTextBox.Width = Width - (LEFT_PADDING + RIGHT_PADDING);
-            baseTextBox.Height = Height - (TOP_PADDING + BOTTOM_PADDING);
+            baseTextBox.Location = new Point((int)(LEFT_PADDING * GetDeviceScaleFactor()), (int)(TOP_PADDING * GetDeviceScaleFactor()));
+            baseTextBox.Width = Width - ((int)(LEFT_PADDING * GetDeviceScaleFactor()) + (int)(RIGHT_PADDING * GetDeviceScaleFactor()));
+            baseTextBox.Height = Height - ((int)(TOP_PADDING * GetDeviceScaleFactor()) + (int)(BOTTOM_PADDING * GetDeviceScaleFactor()));
 
-            LINE_Y = Height - LINE_BOTTOM_PADDING;
+            LINE_Y = Height - (int)(LINE_BOTTOM_PADDING * GetDeviceScaleFactor());
 
         }
 
@@ -959,6 +993,10 @@ namespace ReaLTaiizor.Controls
                 SendKeys.Send("{TAB}");
             }
         }
+
+        [DllImport("gdi32.dll", ExactSpelling = true)]
+        private static extern bool DeleteObject(IntPtr hObject);
+
     }
 
     #endregion

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialMultiLineTextBoxEdit.cs
@@ -4,7 +4,6 @@ using ReaLTaiizor.Child.Material;
 using ReaLTaiizor.Helper;
 using ReaLTaiizor.Manager;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
@@ -839,6 +839,8 @@ namespace ReaLTaiizor.Controls
         private Rectangle _leadingIconBounds;
         private Rectangle _trailingIconBounds;
 
+        private bool _needsLayoutRefresh = false;
+
         private Dictionary<string, TextureBrush> iconsBrushes;
         private Dictionary<string, TextureBrush> iconsErrorBrushes;
 
@@ -975,10 +977,21 @@ namespace ReaLTaiizor.Controls
             ResumeLayout(false);
         }
 
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            _needsLayoutRefresh = true;
+        }
+
         protected override void OnPaint(PaintEventArgs pevent)
         {
             ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
             ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            if (_needsLayoutRefresh)
+            {
+                UpdateRects();
+                _needsLayoutRefresh = false;
+            }
 
             Graphics g = pevent.Graphics;
             g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static ReaLTaiizor.Helper.MaterialDrawHelper;
 using static ReaLTaiizor.Util.MaterialAnimations;
@@ -813,7 +812,7 @@ namespace ReaLTaiizor.Controls
         # endregion
 
         private readonly AnimationManager _animationManager;
-        
+
         public bool isFocused = false;
         private const int PREFIX_SUFFIX_PADDING = 4;
         private const int ICON_SIZE = 24;

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
@@ -985,8 +985,8 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs pevent)
         {
-            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            // ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            // ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
             if (_needsLayoutRefresh)
             {
                 UpdateRects();

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
@@ -87,7 +87,7 @@ namespace ReaLTaiizor.Controls
                 field = value;
                 if (field)
                 {
-                    _helperTextHeight = (int)(HELPER_TEXT_HEIGHT * GetDeviceScaleFactor());
+                    _helperTextHeight = (int)(HELPER_TEXT_HEIGHT * ScaleFactor);
                 }
                 else
                 {
@@ -844,6 +844,40 @@ namespace ReaLTaiizor.Controls
 
         protected readonly MaterialBaseTextBox baseTextBox;
 
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         public MaterialTextBoxEdit()
         {
             // Material Properties
@@ -871,7 +905,7 @@ namespace ReaLTaiizor.Controls
                 preProcessIcons();
             };
 
-            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
 
             baseTextBox = new MaterialBaseTextBox
             {
@@ -879,14 +913,14 @@ namespace ReaLTaiizor.Controls
                 Font = base.Font,
                 ForeColor = SkinManager.TextHighEmphasisColor,
                 Multiline = false,
-                Location = new Point((int)(LEFT_PADDING * GetDeviceScaleFactor()), ((int)(HEIGHT * GetDeviceScaleFactor()) / 2) - ((int)(FONT_HEIGHT * GetDeviceScaleFactor()) / 2)),
-                Width = Width - ((int)(LEFT_PADDING * GetDeviceScaleFactor()) + (int)(RIGHT_PADDING * GetDeviceScaleFactor())),
-                Height = (int)(FONT_HEIGHT * GetDeviceScaleFactor())
+                Location = new Point((int)(LEFT_PADDING * ScaleFactor), ((int)(HEIGHT * ScaleFactor) / 2) - ((int)(FONT_HEIGHT * ScaleFactor) / 2)),
+                Width = Width - ((int)(LEFT_PADDING * ScaleFactor) + (int)(RIGHT_PADDING * ScaleFactor)),
+                Height = (int)(FONT_HEIGHT * ScaleFactor)
             };
 
             Enabled = true;
             ReadOnly = false;
-            Size = new Size(250, (int)(HEIGHT * GetDeviceScaleFactor()));
+            Size = new Size(250, (int)(HEIGHT * ScaleFactor));
 
             UseTallSize = true;
             PrefixSuffix = PrefixSuffixTypes.None;
@@ -933,6 +967,9 @@ namespace ReaLTaiizor.Controls
 
         private void Redraw(object sencer, EventArgs e)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             SuspendLayout();
             Invalidate();
             ResumeLayout(false);
@@ -940,6 +977,9 @@ namespace ReaLTaiizor.Controls
 
         protected override void OnPaint(PaintEventArgs pevent)
         {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+
             Graphics g = pevent.Graphics;
             g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
             g.Clear(Parent.BackColor == Color.Transparent ? ((Parent.Parent == null || (Parent.Parent != null && Parent.Parent.BackColor == Color.Transparent)) ? SkinManager.BackgroundColor : Parent.Parent.BackColor) : Parent.BackColor);
@@ -986,8 +1026,8 @@ namespace ReaLTaiizor.Controls
 
             // HintText
             bool userTextPresent = !string.IsNullOrEmpty(Text);
-            Rectangle helperTextRect = new((int)(LEFT_PADDING * GetDeviceScaleFactor()) - _prefix_padding, LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * GetDeviceScaleFactor()), Width - ((int)(LEFT_PADDING * GetDeviceScaleFactor()) - _prefix_padding) - _right_padding, (int)(HELPER_TEXT_HEIGHT * GetDeviceScaleFactor()));
-            Rectangle hintRect = new(_left_padding - _prefix_padding, (int)(HINT_TEXT_SMALL_Y * GetDeviceScaleFactor()), Width - (_left_padding - _prefix_padding) - _right_padding, (int)(HINT_TEXT_SMALL_SIZE * GetDeviceScaleFactor()));
+            Rectangle helperTextRect = new((int)(LEFT_PADDING * ScaleFactor) - _prefix_padding, LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * ScaleFactor), Width - ((int)(LEFT_PADDING * ScaleFactor) - _prefix_padding) - _right_padding, (int)(HELPER_TEXT_HEIGHT * ScaleFactor));
+            Rectangle hintRect = new(_left_padding - _prefix_padding, (int)(HINT_TEXT_SMALL_Y * ScaleFactor), Width - (_left_padding - _prefix_padding) - _right_padding, (int)(HINT_TEXT_SMALL_SIZE * ScaleFactor));
             int hintTextSize = 12;
 
             // bottom line base
@@ -1028,7 +1068,7 @@ namespace ReaLTaiizor.Controls
                     _prefix_padding,
                     hasHint && UseTallSize ? LINE_Y - (hintRect.Y + hintRect.Height) : LINE_Y);
 
-                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
                 // Draw Prefix text 
                 NativeText.DrawTransparentText(
                 PrefixSuffixText,
@@ -1046,12 +1086,12 @@ namespace ReaLTaiizor.Controls
                 Rectangle suffixRect = new(
                     Width - _right_padding,
                     hasHint && UseTallSize ? hintRect.Y + hintRect.Height - 2 : ClientRectangle.Y,
-                    //NativeText.MeasureLogString(_prefixsuffixText, SkinManager.getLogFontByType(MaterialSkinManager.fontType.Subtitle1)).Width + (int)(PREFIX_SUFFIX_PADDING * GetDeviceScaleFactor()),
+                    //NativeText.MeasureLogString(_prefixsuffixText, SkinManager.getLogFontByType(MaterialSkinManager.fontType.Subtitle1)).Width + (int)(PREFIX_SUFFIX_PADDING * ScaleFactor),
                     _suffix_padding,
                     hasHint && UseTallSize ? LINE_Y - (hintRect.Y + hintRect.Height) : LINE_Y);
 
                 // Draw Suffix text 
-                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
                 NativeText.DrawTransparentText(
                 PrefixSuffixText,
                 font,
@@ -1062,7 +1102,7 @@ namespace ReaLTaiizor.Controls
             }
 
             // Draw hint text
-            IntPtr font2 = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
+            IntPtr font2 = SkinManager.GetTextBoxFontBySize(hintTextSize, ScaleFactor);
             if (hasHint && UseTallSize && (isFocused || userTextPresent))
             {
                 using MaterialNativeTextRenderer NativeText = new(g);
@@ -1081,7 +1121,7 @@ namespace ReaLTaiizor.Controls
             }
 
             // Draw helper text
-            IntPtr font3 = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
+            IntPtr font3 = SkinManager.GetTextBoxFontBySize(hintTextSize, ScaleFactor);
             if (ShowAssistiveText && isFocused && !_errorState)
             {
                 using MaterialNativeTextRenderer NativeText = new(g);
@@ -1100,7 +1140,7 @@ namespace ReaLTaiizor.Controls
             }
 
             // Draw error message
-            IntPtr font4 = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
+            IntPtr font4 = SkinManager.GetTextBoxFontBySize(hintTextSize, ScaleFactor);
             if (ShowAssistiveText && _errorState && ErrorMessage != null)
             {
                 using MaterialNativeTextRenderer NativeText = new(g);
@@ -1201,8 +1241,8 @@ namespace ReaLTaiizor.Controls
             UpdateRects();
             preProcessIcons();
 
-            Size = new Size(Width, (int)(HEIGHT * GetDeviceScaleFactor()));
-            LINE_Y = (int)(HEIGHT * GetDeviceScaleFactor()) - (int)(ACTIVATION_INDICATOR_HEIGHT * GetDeviceScaleFactor()) - _helperTextHeight;
+            Size = new Size(Width, (int)(HEIGHT * ScaleFactor));
+            LINE_Y = (int)(HEIGHT * ScaleFactor) - (int)(ACTIVATION_INDICATOR_HEIGHT * ScaleFactor) - _helperTextHeight;
 
         }
 
@@ -1225,28 +1265,28 @@ namespace ReaLTaiizor.Controls
         private Size ResizeIcon(Image Icon)
         {
             int newWidth, newHeight;
-            //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
-            if (Icon.Width > (int)(ICON_SIZE * GetDeviceScaleFactor()) || Icon.Height > (int)(ICON_SIZE * GetDeviceScaleFactor()))
+            //Resize icon if greater than (int)(ICON_SIZE * ScaleFactor)
+            if (Icon.Width > (int)(ICON_SIZE * ScaleFactor) || Icon.Height > (int)(ICON_SIZE * ScaleFactor))
             {
                 //calculate aspect ratio
                 float aspect = Icon.Width / (float)Icon.Height;
 
                 //calculate new dimensions based on aspect ratio
-                newWidth = (int)((int)(ICON_SIZE * GetDeviceScaleFactor()) * aspect);
+                newWidth = (int)((int)(ICON_SIZE * ScaleFactor) * aspect);
                 newHeight = (int)(newWidth / aspect);
 
                 //if one of the two dimensions exceed the box dimensions
-                if (newWidth > (int)(ICON_SIZE * GetDeviceScaleFactor()) || newHeight > (int)(ICON_SIZE * GetDeviceScaleFactor()))
+                if (newWidth > (int)(ICON_SIZE * ScaleFactor) || newHeight > (int)(ICON_SIZE * ScaleFactor))
                 {
                     //depending on which of the two exceeds the box dimensions set it as the box dimension and calculate the other one based on the aspect ratio
                     if (newWidth > newHeight)
                     {
-                        newWidth = (int)(ICON_SIZE * GetDeviceScaleFactor());
+                        newWidth = (int)(ICON_SIZE * ScaleFactor);
                         newHeight = (int)(newWidth / aspect);
                     }
                     else
                     {
-                        newHeight = (int)(ICON_SIZE * GetDeviceScaleFactor());
+                        newHeight = (int)(ICON_SIZE * ScaleFactor);
                         newWidth = (int)(newHeight * aspect);
                     }
                 }
@@ -1304,7 +1344,7 @@ namespace ReaLTaiizor.Controls
             iconsErrorBrushes = new Dictionary<string, TextureBrush>(2);
 
             // Image Rect
-            Rectangle destRect = new(0, 0, (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
+            Rectangle destRect = new(0, 0, (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
 
             if (LeadingIcon != null)
             {
@@ -1312,7 +1352,7 @@ namespace ReaLTaiizor.Controls
                 // *** _leadingIcon ***
                 // ********************
 
-                //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
+                //Resize icon if greater than (int)(ICON_SIZE * ScaleFactor)
                 Size newSize_leadingIcon = ResizeIcon(LeadingIcon);
                 Bitmap _leadingIconIconResized = new(LeadingIcon, newSize_leadingIcon.Width, newSize_leadingIcon.Height);
 
@@ -1369,7 +1409,7 @@ namespace ReaLTaiizor.Controls
                 // *** _trailingIcon ***
                 // *********************
 
-                //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
+                //Resize icon if greater than (int)(ICON_SIZE * ScaleFactor)
                 Size newSize_trailingIcon = ResizeIcon(TrailingIcon);
                 Bitmap _trailingIconResized = new(TrailingIcon, newSize_trailingIcon.Width, newSize_trailingIcon.Height);
 
@@ -1427,34 +1467,34 @@ namespace ReaLTaiizor.Controls
         {
             HEIGHT = UseTallSize ? 48 : 36;
             HEIGHT += _helperTextHeight;
-            Size = new Size(Size.Width, (int)(HEIGHT * GetDeviceScaleFactor()));
+            Size = new Size(Size.Width, (int)(HEIGHT * ScaleFactor));
         }
 
         private void UpdateRects()
         {
             if (LeadingIcon != null)
             {
-                _left_padding = (int)(LEFT_PADDING * GetDeviceScaleFactor()) + (int)(ICON_SIZE * GetDeviceScaleFactor());
+                _left_padding = (int)(LEFT_PADDING * ScaleFactor) + (int)(ICON_SIZE * ScaleFactor);
             }
             else
             {
-                _left_padding = (int)(LEFT_PADDING * GetDeviceScaleFactor());
+                _left_padding = (int)(LEFT_PADDING * ScaleFactor);
             }
 
             if (TrailingIcon != null)
             {
-                _right_padding = (int)(RIGHT_PADDING * GetDeviceScaleFactor()) + (int)(ICON_SIZE * GetDeviceScaleFactor());
+                _right_padding = (int)(RIGHT_PADDING * ScaleFactor) + (int)(ICON_SIZE * ScaleFactor);
             }
             else
             {
-                _right_padding = (int)(RIGHT_PADDING * GetDeviceScaleFactor());
+                _right_padding = (int)(RIGHT_PADDING * ScaleFactor);
             }
 
             if (PrefixSuffix == PrefixSuffixTypes.Prefix && PrefixSuffixText != null && PrefixSuffixText.Length > 0)
             {
-                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
                 using MaterialNativeTextRenderer NativeText = new(CreateGraphics());
-                _prefix_padding = NativeText.MeasureLogString(PrefixSuffixText, font).Width + (int)(PREFIX_SUFFIX_PADDING * GetDeviceScaleFactor());
+                _prefix_padding = NativeText.MeasureLogString(PrefixSuffixText, font).Width + (int)(PREFIX_SUFFIX_PADDING * ScaleFactor);
                 _left_padding += _prefix_padding;
             }
             else
@@ -1464,9 +1504,9 @@ namespace ReaLTaiizor.Controls
 
             if (PrefixSuffix == PrefixSuffixTypes.Suffix && PrefixSuffixText != null && PrefixSuffixText.Length > 0)
             {
-                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, ScaleFactor);
                 using MaterialNativeTextRenderer NativeText = new(CreateGraphics());
-                _suffix_padding = NativeText.MeasureLogString(PrefixSuffixText, font).Width + (int)(PREFIX_SUFFIX_PADDING * GetDeviceScaleFactor());
+                _suffix_padding = NativeText.MeasureLogString(PrefixSuffixText, font).Width + (int)(PREFIX_SUFFIX_PADDING * ScaleFactor);
                 _right_padding += _suffix_padding;
             }
             else
@@ -1476,19 +1516,19 @@ namespace ReaLTaiizor.Controls
 
             if (hasHint && UseTallSize && (isFocused || !string.IsNullOrEmpty(Text)))
             {
-                baseTextBox.Location = new Point(_left_padding, (int)(BASE_TEXTBOX_HEIGHT * GetDeviceScaleFactor()));
+                baseTextBox.Location = new Point(_left_padding, (int)(BASE_TEXTBOX_HEIGHT * ScaleFactor));
                 baseTextBox.Width = Width - (_left_padding + _right_padding);
-                baseTextBox.Height = (int)(FONT_HEIGHT * GetDeviceScaleFactor());
+                baseTextBox.Height = (int)(FONT_HEIGHT * ScaleFactor);
             }
             else
             {
-                baseTextBox.Location = new Point(_left_padding, ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * GetDeviceScaleFactor())) / 2) - ((int)(FONT_HEIGHT * GetDeviceScaleFactor()) / 2));
+                baseTextBox.Location = new Point(_left_padding, ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * ScaleFactor)) / 2) - ((int)(FONT_HEIGHT * ScaleFactor) / 2));
                 baseTextBox.Width = Width - (_left_padding + _right_padding);
-                baseTextBox.Height = (int)(FONT_HEIGHT * GetDeviceScaleFactor());
+                baseTextBox.Height = (int)(FONT_HEIGHT * ScaleFactor);
             }
 
-            _leadingIconBounds = new Rectangle(8, ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * GetDeviceScaleFactor())) / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
-            _trailingIconBounds = new Rectangle(Width - ((int)(ICON_SIZE * GetDeviceScaleFactor()) + 8), ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * GetDeviceScaleFactor())) / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
+            _leadingIconBounds = new Rectangle(8, ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * ScaleFactor)) / 2) - ((int)(ICON_SIZE * ScaleFactor) / 2), (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
+            _trailingIconBounds = new Rectangle(Width - ((int)(ICON_SIZE * ScaleFactor) + 8), ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * ScaleFactor)) / 2) - ((int)(ICON_SIZE * ScaleFactor) / 2), (int)(ICON_SIZE * ScaleFactor), (int)(ICON_SIZE * ScaleFactor));
         }
 
         public void SetErrorState(bool ErrorState)
@@ -1550,21 +1590,6 @@ namespace ReaLTaiizor.Controls
             }
         }
 
-        private float GetDeviceScaleFactor()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)this.DeviceDpi / 96f;
-            return scalingFactor;
-        }
-
-        private float GetDeviceScaleFactorSqrt()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            return scalingFactor;
-        }
-
         private void LeaveOnEnterKey_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Enter)
@@ -1574,9 +1599,6 @@ namespace ReaLTaiizor.Controls
                 SendKeys.Send("{TAB}");
             }
         }
-
-        [DllImport("gdi32.dll", ExactSpelling = true)]
-        private static extern bool DeleteObject(IntPtr hObject);
 
     }
 

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
@@ -841,7 +841,6 @@ namespace ReaLTaiizor.Controls
 
         private Dictionary<string, TextureBrush> iconsBrushes;
         private Dictionary<string, TextureBrush> iconsErrorBrushes;
-        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
 
         protected readonly MaterialBaseTextBox baseTextBox;
 
@@ -1030,7 +1029,6 @@ namespace ReaLTaiizor.Controls
                     hasHint && UseTallSize ? LINE_Y - (hintRect.Y + hintRect.Height) : LINE_Y);
 
                 IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
-                LFontToBeReleased.Add(font);
                 // Draw Prefix text 
                 NativeText.DrawTransparentText(
                 PrefixSuffixText,
@@ -1054,7 +1052,6 @@ namespace ReaLTaiizor.Controls
 
                 // Draw Suffix text 
                 IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
-                LFontToBeReleased.Add(font);
                 NativeText.DrawTransparentText(
                 PrefixSuffixText,
                 font,
@@ -1066,7 +1063,6 @@ namespace ReaLTaiizor.Controls
 
             // Draw hint text
             IntPtr font2 = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
-            LFontToBeReleased.Add(font2);
             if (hasHint && UseTallSize && (isFocused || userTextPresent))
             {
                 using MaterialNativeTextRenderer NativeText = new(g);
@@ -1086,7 +1082,6 @@ namespace ReaLTaiizor.Controls
 
             // Draw helper text
             IntPtr font3 = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
-            LFontToBeReleased.Add(font3);
             if (ShowAssistiveText && isFocused && !_errorState)
             {
                 using MaterialNativeTextRenderer NativeText = new(g);
@@ -1106,7 +1101,6 @@ namespace ReaLTaiizor.Controls
 
             // Draw error message
             IntPtr font4 = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
-            LFontToBeReleased.Add(font4);
             if (ShowAssistiveText && _errorState && ErrorMessage != null)
             {
                 using MaterialNativeTextRenderer NativeText = new(g);
@@ -1223,18 +1217,6 @@ namespace ReaLTaiizor.Controls
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                // Release handle from CreateFont / LogFont
-                foreach (IntPtr handle in LFontToBeReleased)
-                {
-                    if (handle != IntPtr.Zero)
-                    {
-                        DeleteObject(handle);
-                    }
-                }
-                LFontToBeReleased.Clear();
-            }
             base.Dispose(disposing);
         }
 
@@ -1471,7 +1453,6 @@ namespace ReaLTaiizor.Controls
             if (PrefixSuffix == PrefixSuffixTypes.Prefix && PrefixSuffixText != null && PrefixSuffixText.Length > 0)
             {
                 IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
-                LFontToBeReleased.Add(font);
                 using MaterialNativeTextRenderer NativeText = new(CreateGraphics());
                 _prefix_padding = NativeText.MeasureLogString(PrefixSuffixText, font).Width + (int)(PREFIX_SUFFIX_PADDING * GetDeviceScaleFactor());
                 _left_padding += _prefix_padding;
@@ -1484,7 +1465,6 @@ namespace ReaLTaiizor.Controls
             if (PrefixSuffix == PrefixSuffixTypes.Suffix && PrefixSuffixText != null && PrefixSuffixText.Length > 0)
             {
                 IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
-                LFontToBeReleased.Add(font);
                 using MaterialNativeTextRenderer NativeText = new(CreateGraphics());
                 _suffix_padding = NativeText.MeasureLogString(PrefixSuffixText, font).Width + (int)(PREFIX_SUFFIX_PADDING * GetDeviceScaleFactor());
                 _right_padding += _suffix_padding;

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
@@ -857,10 +857,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -873,10 +871,8 @@ namespace ReaLTaiizor.Controls
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public MaterialTextBoxEdit()

--- a/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
+++ b/src/ReaLTaiizor/Controls/TextBoxEdit/MaterialTextBoxEdit.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static ReaLTaiizor.Helper.MaterialDrawHelper;
 using static ReaLTaiizor.Util.MaterialAnimations;
@@ -31,7 +32,7 @@ namespace ReaLTaiizor.Controls
         [Browsable(false)]
         public MaterialSkinManager SkinManager => MaterialSkinManager.Instance;
 
-        public bool Focus()
+        public new bool Focus()
         {
             return baseTextBox.Focus();
         }
@@ -86,7 +87,7 @@ namespace ReaLTaiizor.Controls
                 field = value;
                 if (field)
                 {
-                    _helperTextHeight = HELPER_TEXT_HEIGHT;
+                    _helperTextHeight = (int)(HELPER_TEXT_HEIGHT * GetDeviceScaleFactor());
                 }
                 else
                 {
@@ -812,7 +813,7 @@ namespace ReaLTaiizor.Controls
         # endregion
 
         private readonly AnimationManager _animationManager;
-
+        
         public bool isFocused = false;
         private const int PREFIX_SUFFIX_PADDING = 4;
         private const int ICON_SIZE = 24;
@@ -823,6 +824,7 @@ namespace ReaLTaiizor.Controls
         private const int ACTIVATION_INDICATOR_HEIGHT = 2;
         private const int HELPER_TEXT_HEIGHT = 16;
         private const int FONT_HEIGHT = 20;
+        private const int BASE_TEXTBOX_HEIGHT = 22;
 
         private int HEIGHT = 48;
 
@@ -839,6 +841,7 @@ namespace ReaLTaiizor.Controls
 
         private Dictionary<string, TextureBrush> iconsBrushes;
         private Dictionary<string, TextureBrush> iconsErrorBrushes;
+        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
 
         protected readonly MaterialBaseTextBox baseTextBox;
 
@@ -869,7 +872,7 @@ namespace ReaLTaiizor.Controls
                 preProcessIcons();
             };
 
-            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1);
+            Font = SkinManager.GetFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
 
             baseTextBox = new MaterialBaseTextBox
             {
@@ -877,14 +880,14 @@ namespace ReaLTaiizor.Controls
                 Font = base.Font,
                 ForeColor = SkinManager.TextHighEmphasisColor,
                 Multiline = false,
-                Location = new Point(LEFT_PADDING, (HEIGHT / 2) - (FONT_HEIGHT / 2)),
-                Width = Width - (LEFT_PADDING + RIGHT_PADDING),
-                Height = FONT_HEIGHT
+                Location = new Point((int)(LEFT_PADDING * GetDeviceScaleFactor()), ((int)(HEIGHT * GetDeviceScaleFactor()) / 2) - ((int)(FONT_HEIGHT * GetDeviceScaleFactor()) / 2)),
+                Width = Width - ((int)(LEFT_PADDING * GetDeviceScaleFactor()) + (int)(RIGHT_PADDING * GetDeviceScaleFactor())),
+                Height = (int)(FONT_HEIGHT * GetDeviceScaleFactor())
             };
 
             Enabled = true;
             ReadOnly = false;
-            Size = new Size(250, HEIGHT);
+            Size = new Size(250, (int)(HEIGHT * GetDeviceScaleFactor()));
 
             UseTallSize = true;
             PrefixSuffix = PrefixSuffixTypes.None;
@@ -984,8 +987,8 @@ namespace ReaLTaiizor.Controls
 
             // HintText
             bool userTextPresent = !string.IsNullOrEmpty(Text);
-            Rectangle helperTextRect = new(LEFT_PADDING - _prefix_padding, LINE_Y + ACTIVATION_INDICATOR_HEIGHT, Width - (LEFT_PADDING - _prefix_padding) - _right_padding, HELPER_TEXT_HEIGHT);
-            Rectangle hintRect = new(_left_padding - _prefix_padding, HINT_TEXT_SMALL_Y, Width - (_left_padding - _prefix_padding) - _right_padding, HINT_TEXT_SMALL_SIZE);
+            Rectangle helperTextRect = new((int)(LEFT_PADDING * GetDeviceScaleFactor()) - _prefix_padding, LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * GetDeviceScaleFactor()), Width - ((int)(LEFT_PADDING * GetDeviceScaleFactor()) - _prefix_padding) - _right_padding, (int)(HELPER_TEXT_HEIGHT * GetDeviceScaleFactor()));
+            Rectangle hintRect = new(_left_padding - _prefix_padding, (int)(HINT_TEXT_SMALL_Y * GetDeviceScaleFactor()), Width - (_left_padding - _prefix_padding) - _right_padding, (int)(HINT_TEXT_SMALL_SIZE * GetDeviceScaleFactor()));
             int hintTextSize = 12;
 
             // bottom line base
@@ -1026,10 +1029,12 @@ namespace ReaLTaiizor.Controls
                     _prefix_padding,
                     hasHint && UseTallSize ? LINE_Y - (hintRect.Y + hintRect.Height) : LINE_Y);
 
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                LFontToBeReleased.Add(font);
                 // Draw Prefix text 
                 NativeText.DrawTransparentText(
                 PrefixSuffixText,
-                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1),
+                font,
                 Enabled ? SkinManager.TextMediumEmphasisColor : SkinManager.TextDisabledOrHintColor,
                 prefixRect.Location,
                 prefixRect.Size,
@@ -1043,14 +1048,16 @@ namespace ReaLTaiizor.Controls
                 Rectangle suffixRect = new(
                     Width - _right_padding,
                     hasHint && UseTallSize ? hintRect.Y + hintRect.Height - 2 : ClientRectangle.Y,
-                    //NativeText.MeasureLogString(_prefixsuffixText, SkinManager.getLogFontByType(MaterialSkinManager.fontType.Subtitle1)).Width + PREFIX_SUFFIX_PADDING,
+                    //NativeText.MeasureLogString(_prefixsuffixText, SkinManager.getLogFontByType(MaterialSkinManager.fontType.Subtitle1)).Width + (int)(PREFIX_SUFFIX_PADDING * GetDeviceScaleFactor()),
                     _suffix_padding,
                     hasHint && UseTallSize ? LINE_Y - (hintRect.Y + hintRect.Height) : LINE_Y);
 
                 // Draw Suffix text 
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                LFontToBeReleased.Add(font);
                 NativeText.DrawTransparentText(
                 PrefixSuffixText,
-                SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1),
+                font,
                 Enabled ? SkinManager.TextMediumEmphasisColor : SkinManager.TextDisabledOrHintColor,
                 suffixRect.Location,
                 suffixRect.Size,
@@ -1058,12 +1065,14 @@ namespace ReaLTaiizor.Controls
             }
 
             // Draw hint text
+            IntPtr font2 = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
+            LFontToBeReleased.Add(font2);
             if (hasHint && UseTallSize && (isFocused || userTextPresent))
             {
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                 Hint,
-                SkinManager.GetTextBoxFontBySize(hintTextSize),
+                font2,
                 Enabled ? !_errorState || (!userTextPresent && !isFocused) ? isFocused ? UseAccent ?
                 SkinManager.ColorScheme.AccentColor : // Focus Accent
                 SkinManager.ColorScheme.PrimaryColor : // Focus Primary
@@ -1076,12 +1085,14 @@ namespace ReaLTaiizor.Controls
             }
 
             // Draw helper text
+            IntPtr font3 = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
+            LFontToBeReleased.Add(font3);
             if (ShowAssistiveText && isFocused && !_errorState)
             {
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                 HelperText,
-                SkinManager.GetTextBoxFontBySize(hintTextSize),
+                font3,
                 Enabled ? !_errorState || (!userTextPresent && !isFocused) ? isFocused ? UseAccent ?
                 SkinManager.ColorScheme.AccentColor : // Focus Accent
                 SkinManager.ColorScheme.PrimaryColor : // Focus Primary
@@ -1094,12 +1105,14 @@ namespace ReaLTaiizor.Controls
             }
 
             // Draw error message
+            IntPtr font4 = SkinManager.GetTextBoxFontBySize(hintTextSize, GetDeviceScaleFactor());
+            LFontToBeReleased.Add(font4);
             if (ShowAssistiveText && _errorState && ErrorMessage != null)
             {
                 using MaterialNativeTextRenderer NativeText = new(g);
                 NativeText.DrawTransparentText(
                 ErrorMessage,
-                SkinManager.GetTextBoxFontBySize(hintTextSize),
+                font4,
                 Enabled ?
                 SkinManager.BackgroundHoverRedColor : // error state
                 SkinManager.TextDisabledOrHintColor, // Disabled
@@ -1194,8 +1207,8 @@ namespace ReaLTaiizor.Controls
             UpdateRects();
             preProcessIcons();
 
-            Size = new Size(Width, HEIGHT);
-            LINE_Y = HEIGHT - ACTIVATION_INDICATOR_HEIGHT - _helperTextHeight;
+            Size = new Size(Width, (int)(HEIGHT * GetDeviceScaleFactor()));
+            LINE_Y = (int)(HEIGHT * GetDeviceScaleFactor()) - (int)(ACTIVATION_INDICATOR_HEIGHT * GetDeviceScaleFactor()) - _helperTextHeight;
 
         }
 
@@ -1208,33 +1221,50 @@ namespace ReaLTaiizor.Controls
 
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Release handle from CreateFont / LogFont
+                foreach (IntPtr handle in LFontToBeReleased)
+                {
+                    if (handle != IntPtr.Zero)
+                    {
+                        DeleteObject(handle);
+                    }
+                }
+                LFontToBeReleased.Clear();
+            }
+            base.Dispose(disposing);
+        }
+
         #region Icon
 
-        private static Size ResizeIcon(Image Icon)
+        private Size ResizeIcon(Image Icon)
         {
             int newWidth, newHeight;
-            //Resize icon if greater than ICON_SIZE
-            if (Icon.Width > ICON_SIZE || Icon.Height > ICON_SIZE)
+            //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
+            if (Icon.Width > (int)(ICON_SIZE * GetDeviceScaleFactor()) || Icon.Height > (int)(ICON_SIZE * GetDeviceScaleFactor()))
             {
                 //calculate aspect ratio
                 float aspect = Icon.Width / (float)Icon.Height;
 
                 //calculate new dimensions based on aspect ratio
-                newWidth = (int)(ICON_SIZE * aspect);
+                newWidth = (int)((int)(ICON_SIZE * GetDeviceScaleFactor()) * aspect);
                 newHeight = (int)(newWidth / aspect);
 
                 //if one of the two dimensions exceed the box dimensions
-                if (newWidth > ICON_SIZE || newHeight > ICON_SIZE)
+                if (newWidth > (int)(ICON_SIZE * GetDeviceScaleFactor()) || newHeight > (int)(ICON_SIZE * GetDeviceScaleFactor()))
                 {
                     //depending on which of the two exceeds the box dimensions set it as the box dimension and calculate the other one based on the aspect ratio
                     if (newWidth > newHeight)
                     {
-                        newWidth = ICON_SIZE;
+                        newWidth = (int)(ICON_SIZE * GetDeviceScaleFactor());
                         newHeight = (int)(newWidth / aspect);
                     }
                     else
                     {
-                        newHeight = ICON_SIZE;
+                        newHeight = (int)(ICON_SIZE * GetDeviceScaleFactor());
                         newWidth = (int)(newHeight * aspect);
                     }
                 }
@@ -1292,7 +1322,7 @@ namespace ReaLTaiizor.Controls
             iconsErrorBrushes = new Dictionary<string, TextureBrush>(2);
 
             // Image Rect
-            Rectangle destRect = new(0, 0, ICON_SIZE, ICON_SIZE);
+            Rectangle destRect = new(0, 0, (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
 
             if (LeadingIcon != null)
             {
@@ -1300,7 +1330,7 @@ namespace ReaLTaiizor.Controls
                 // *** _leadingIcon ***
                 // ********************
 
-                //Resize icon if greater than ICON_SIZE
+                //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
                 Size newSize_leadingIcon = ResizeIcon(LeadingIcon);
                 Bitmap _leadingIconIconResized = new(LeadingIcon, newSize_leadingIcon.Width, newSize_leadingIcon.Height);
 
@@ -1357,7 +1387,7 @@ namespace ReaLTaiizor.Controls
                 // *** _trailingIcon ***
                 // *********************
 
-                //Resize icon if greater than ICON_SIZE
+                //Resize icon if greater than (int)(ICON_SIZE * GetDeviceScaleFactor())
                 Size newSize_trailingIcon = ResizeIcon(TrailingIcon);
                 Bitmap _trailingIconResized = new(TrailingIcon, newSize_trailingIcon.Width, newSize_trailingIcon.Height);
 
@@ -1415,33 +1445,35 @@ namespace ReaLTaiizor.Controls
         {
             HEIGHT = UseTallSize ? 48 : 36;
             HEIGHT += _helperTextHeight;
-            Size = new Size(Size.Width, HEIGHT);
+            Size = new Size(Size.Width, (int)(HEIGHT * GetDeviceScaleFactor()));
         }
 
         private void UpdateRects()
         {
             if (LeadingIcon != null)
             {
-                _left_padding = LEFT_PADDING + ICON_SIZE;
+                _left_padding = (int)(LEFT_PADDING * GetDeviceScaleFactor()) + (int)(ICON_SIZE * GetDeviceScaleFactor());
             }
             else
             {
-                _left_padding = LEFT_PADDING;
+                _left_padding = (int)(LEFT_PADDING * GetDeviceScaleFactor());
             }
 
             if (TrailingIcon != null)
             {
-                _right_padding = RIGHT_PADDING + ICON_SIZE;
+                _right_padding = (int)(RIGHT_PADDING * GetDeviceScaleFactor()) + (int)(ICON_SIZE * GetDeviceScaleFactor());
             }
             else
             {
-                _right_padding = RIGHT_PADDING;
+                _right_padding = (int)(RIGHT_PADDING * GetDeviceScaleFactor());
             }
 
             if (PrefixSuffix == PrefixSuffixTypes.Prefix && PrefixSuffixText != null && PrefixSuffixText.Length > 0)
             {
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                LFontToBeReleased.Add(font);
                 using MaterialNativeTextRenderer NativeText = new(CreateGraphics());
-                _prefix_padding = NativeText.MeasureLogString(PrefixSuffixText, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1)).Width + PREFIX_SUFFIX_PADDING;
+                _prefix_padding = NativeText.MeasureLogString(PrefixSuffixText, font).Width + (int)(PREFIX_SUFFIX_PADDING * GetDeviceScaleFactor());
                 _left_padding += _prefix_padding;
             }
             else
@@ -1451,8 +1483,10 @@ namespace ReaLTaiizor.Controls
 
             if (PrefixSuffix == PrefixSuffixTypes.Suffix && PrefixSuffixText != null && PrefixSuffixText.Length > 0)
             {
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1, GetDeviceScaleFactor());
+                LFontToBeReleased.Add(font);
                 using MaterialNativeTextRenderer NativeText = new(CreateGraphics());
-                _suffix_padding = NativeText.MeasureLogString(PrefixSuffixText, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle1)).Width + PREFIX_SUFFIX_PADDING;
+                _suffix_padding = NativeText.MeasureLogString(PrefixSuffixText, font).Width + (int)(PREFIX_SUFFIX_PADDING * GetDeviceScaleFactor());
                 _right_padding += _suffix_padding;
             }
             else
@@ -1462,19 +1496,19 @@ namespace ReaLTaiizor.Controls
 
             if (hasHint && UseTallSize && (isFocused || !string.IsNullOrEmpty(Text)))
             {
-                baseTextBox.Location = new Point(_left_padding, 22);
+                baseTextBox.Location = new Point(_left_padding, (int)(BASE_TEXTBOX_HEIGHT * GetDeviceScaleFactor()));
                 baseTextBox.Width = Width - (_left_padding + _right_padding);
-                baseTextBox.Height = FONT_HEIGHT;
+                baseTextBox.Height = (int)(FONT_HEIGHT * GetDeviceScaleFactor());
             }
             else
             {
-                baseTextBox.Location = new Point(_left_padding, ((LINE_Y + ACTIVATION_INDICATOR_HEIGHT) / 2) - (FONT_HEIGHT / 2));
+                baseTextBox.Location = new Point(_left_padding, ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * GetDeviceScaleFactor())) / 2) - ((int)(FONT_HEIGHT * GetDeviceScaleFactor()) / 2));
                 baseTextBox.Width = Width - (_left_padding + _right_padding);
-                baseTextBox.Height = FONT_HEIGHT;
+                baseTextBox.Height = (int)(FONT_HEIGHT * GetDeviceScaleFactor());
             }
 
-            _leadingIconBounds = new Rectangle(8, ((LINE_Y + ACTIVATION_INDICATOR_HEIGHT) / 2) - (ICON_SIZE / 2), ICON_SIZE, ICON_SIZE);
-            _trailingIconBounds = new Rectangle(Width - (ICON_SIZE + 8), ((LINE_Y + ACTIVATION_INDICATOR_HEIGHT) / 2) - (ICON_SIZE / 2), ICON_SIZE, ICON_SIZE);
+            _leadingIconBounds = new Rectangle(8, ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * GetDeviceScaleFactor())) / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
+            _trailingIconBounds = new Rectangle(Width - ((int)(ICON_SIZE * GetDeviceScaleFactor()) + 8), ((LINE_Y + (int)(ACTIVATION_INDICATOR_HEIGHT * GetDeviceScaleFactor())) / 2) - ((int)(ICON_SIZE * GetDeviceScaleFactor()) / 2), (int)(ICON_SIZE * GetDeviceScaleFactor()), (int)(ICON_SIZE * GetDeviceScaleFactor()));
         }
 
         public void SetErrorState(bool ErrorState)
@@ -1536,6 +1570,21 @@ namespace ReaLTaiizor.Controls
             }
         }
 
+        private float GetDeviceScaleFactor()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)this.DeviceDpi / 96f;
+            return scalingFactor;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
+        }
+
         private void LeaveOnEnterKey_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Enter)
@@ -1545,6 +1594,10 @@ namespace ReaLTaiizor.Controls
                 SendKeys.Send("{TAB}");
             }
         }
+
+        [DllImport("gdi32.dll", ExactSpelling = true)]
+        private static extern bool DeleteObject(IntPtr hObject);
+
     }
 
     #endregion

--- a/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
@@ -27,7 +27,7 @@ namespace ReaLTaiizor.Forms
 
         public static double MAX_HEIGHT_FACTOR = 0.9;
 
-        private MaterialMultiLineTextBox richTextBoxMessage;
+        private MaterialMultiLineTextBoxEdit richTextBoxMessage;
         private MaterialLabel materialLabel1;
         private MaterialButton leftButton;
         private MaterialButton middleButton;
@@ -62,7 +62,7 @@ namespace ReaLTaiizor.Forms
             this.messageContainer = new System.Windows.Forms.Panel();
             this.materialLabel1 = new MaterialLabel();
             this.pictureBoxForIcon = new System.Windows.Forms.PictureBox();
-            this.richTextBoxMessage = new MaterialMultiLineTextBox();
+            this.richTextBoxMessage = new MaterialMultiLineTextBoxEdit();
             this.leftButton = new MaterialButton();
             this.middleButton = new MaterialButton();
             this.rightButton = new MaterialButton();
@@ -116,7 +116,7 @@ namespace ReaLTaiizor.Forms
             | System.Windows.Forms.AnchorStyles.Left
             | System.Windows.Forms.AnchorStyles.Right);
             this.richTextBoxMessage.BackColor = System.Drawing.Color.FromArgb((int)(byte)255, (int)(byte)255, (int)(byte)255);
-            this.richTextBoxMessage.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            //this.richTextBoxMessage.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.richTextBoxMessage.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.MaterialFlexibleFormBindingSource, "MessageText", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.richTextBoxMessage.Depth = 0;
             this.richTextBoxMessage.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, (byte)0);
@@ -126,12 +126,12 @@ namespace ReaLTaiizor.Forms
             this.richTextBoxMessage.MouseState = MaterialMouseState.HOVER;
             this.richTextBoxMessage.Name = "richTextBoxMessage";
             this.richTextBoxMessage.ReadOnly = true;
-            this.richTextBoxMessage.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
+            this.richTextBoxMessage.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.richTextBoxMessage.Size = new System.Drawing.Size(314, 65);
             this.richTextBoxMessage.TabIndex = 0;
             this.richTextBoxMessage.TabStop = false;
             this.richTextBoxMessage.Text = "<Message>";
-            this.richTextBoxMessage.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.richTextBoxMessage_LinkClicked);
+            //this.richTextBoxMessage.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.richTextBoxMessage_LinkClicked);
             // 
             // leftButton
             // 

--- a/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
@@ -428,7 +428,6 @@ namespace ReaLTaiizor.Forms
         private Rectangle _drawerButtonBounds => new(ClientRectangle.X + (SkinManager.FORM_PADDING / 2) + 3, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + ((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) - ((int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt()) / 2), ((int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt())), (int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt()));
         private Rectangle _statusBarBounds => new(ClientRectangle.X, ClientRectangle.Y, ClientSize.Width, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
         private Rectangle _drawerIconRect;
-        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
 
         private bool Maximized
         {
@@ -934,18 +933,6 @@ namespace ReaLTaiizor.Forms
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                // Release handle from CreateFont / LogFont
-                foreach (IntPtr handle in LFontToBeReleased)
-                {
-                    if (handle != IntPtr.Zero)
-                    {
-                        DeleteObject(handle);
-                    }
-                }
-                LFontToBeReleased.Clear();
-            }
             base.Dispose(disposing);
         }
 
@@ -1397,7 +1384,6 @@ namespace ReaLTaiizor.Forms
                 //Form title
                 using MaterialNativeTextRenderer NativeText = new(g);
                 var font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6, GetDeviceScaleFactor());
-                LFontToBeReleased.Add(font);
                 Rectangle textLocation = new(DrawerTabControl != null ? (int)(TITLE_LEFT_PADDING * GetDeviceScaleFactorSqrt()) : (int)(TITLE_LEFT_PADDING * GetDeviceScaleFactorSqrt()) - ((int)(ICON_SIZE * GetDeviceScaleFactorSqrt()) + ((int)(ACTION_BAR_PADDING * GetDeviceScaleFactorSqrt()) * 2)), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
                 NativeText.DrawTransparentText(Text, font,
                     SkinManager.ColorScheme.TextColor,
@@ -1410,7 +1396,6 @@ namespace ReaLTaiizor.Forms
                 //Form title
                 using MaterialNativeTextRenderer NativeText = new(g);
                 var font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2, GetDeviceScaleFactor());
-                LFontToBeReleased.Add(font);
                 Rectangle textLocation = new(10, 4, ClientSize.Width, ClientSize.Height);
                 NativeText.DrawTransparentText(Text, font,
                     SkinManager.ColorScheme.TextColor,

--- a/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
@@ -26,6 +26,13 @@ namespace ReaLTaiizor.Forms
     public class MaterialForm : Form, MaterialControlI
     {
         #region Public Properties
+
+        /// <summary>
+        /// Indicate if the form should respond to System Dpi Scaling Ratio
+        /// </summary>
+        [DefaultValue(true)]
+        public bool ScalingAware { get; set; } = true;
+
         [Browsable(false)]
         public int Depth { get; set; }
 
@@ -259,7 +266,7 @@ namespace ReaLTaiizor.Forms
             set => base.FormBorderStyle = value;
         }
 
-        public Rectangle UserArea => new(ClientRectangle.X, ClientRectangle.Y + STATUS_BAR_HEIGHT + ACTION_BAR_HEIGHT, ClientSize.Width, ClientSize.Height - (STATUS_BAR_HEIGHT + ACTION_BAR_HEIGHT));
+        public Rectangle UserArea => new(ClientRectangle.X, ClientRectangle.Y + (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), ClientSize.Width, ClientSize.Height - ((int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt())));
         #endregion
 
         #region Enums
@@ -414,12 +421,12 @@ namespace ReaLTaiizor.Forms
         private ResizeDirection _resizeDir;
         private ButtonState _buttonState = ButtonState.None;
 
-        private Rectangle _minButtonBounds => new(ClientSize.Width - (3 * STATUS_BAR_BUTTON_WIDTH), ClientRectangle.Y, STATUS_BAR_BUTTON_WIDTH, STATUS_BAR_HEIGHT);
-        private Rectangle _maxButtonBounds => new(ClientSize.Width - (2 * STATUS_BAR_BUTTON_WIDTH), ClientRectangle.Y, STATUS_BAR_BUTTON_WIDTH, STATUS_BAR_HEIGHT);
-        private Rectangle _xButtonBounds => new(ClientSize.Width - STATUS_BAR_BUTTON_WIDTH, ClientRectangle.Y, STATUS_BAR_BUTTON_WIDTH, STATUS_BAR_HEIGHT);
-        private Rectangle _actionBarBounds => new(ClientRectangle.X, ClientRectangle.Y + STATUS_BAR_HEIGHT, ClientSize.Width, ACTION_BAR_HEIGHT);
-        private Rectangle _drawerButtonBounds => new(ClientRectangle.X + (SkinManager.FORM_PADDING / 2) + 3, STATUS_BAR_HEIGHT + (ACTION_BAR_HEIGHT / 2) - (ACTION_BAR_HEIGHT_DEFAULT / 2), ACTION_BAR_HEIGHT_DEFAULT, ACTION_BAR_HEIGHT_DEFAULT);
-        private Rectangle _statusBarBounds => new(ClientRectangle.X, ClientRectangle.Y, ClientSize.Width, STATUS_BAR_HEIGHT);
+        private Rectangle _minButtonBounds => new(ClientSize.Width - (3 * (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor())), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor()), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
+        private Rectangle _maxButtonBounds => new(ClientSize.Width - (2 * (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor())), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor()), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
+        private Rectangle _xButtonBounds => new(ClientSize.Width - (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor()), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor()), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
+        private Rectangle _actionBarBounds => new(ClientRectangle.X, ClientRectangle.Y + (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
+        private Rectangle _drawerButtonBounds => new(ClientRectangle.X + (SkinManager.FORM_PADDING / 2) + 3, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + ((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) - ((int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt()) / 2), ((int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt())), (int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt()));
+        private Rectangle _statusBarBounds => new(ClientRectangle.X, ClientRectangle.Y, ClientSize.Width, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
         private Rectangle _drawerIconRect;
 
         private bool Maximized
@@ -476,7 +483,7 @@ namespace ReaLTaiizor.Forms
             FormStyle = FormStyles.ActionBar_40;
 
             //Keep space for resize by mouse
-            Padding = new Padding(PADDING_MINIMUM, STATUS_BAR_HEIGHT + ACTION_BAR_HEIGHT, PADDING_MINIMUM, PADDING_MINIMUM);
+            Padding = new Padding((int)(PADDING_MINIMUM * GetDeviceScaleFactorSqrt()), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), (int)(PADDING_MINIMUM * GetDeviceScaleFactorSqrt()), (int)(PADDING_MINIMUM * GetDeviceScaleFactorSqrt()));
 
             _clickAnimManager = new AnimationManager()
             {
@@ -498,6 +505,26 @@ namespace ReaLTaiizor.Forms
         }
 
         #region Private Methods
+
+
+
+
+        private float GetDeviceScaleFactor()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)this.DeviceDpi / 96f;
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            // Buttons are not included in sqrt controls.
+            return scalingFactor;
+        }
+
+        private float GetDeviceScaleFactorSqrt()
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
+        }
         protected void AddDrawerOverlayForm()
         {
             if (DrawerTabControl == null)
@@ -703,7 +730,7 @@ namespace ReaLTaiizor.Forms
             }
             else
             {
-                Padding = new Padding(PADDING_MINIMUM, originalPadding.Top, originalPadding.Right, originalPadding.Bottom);
+                Padding = new Padding((int)(PADDING_MINIMUM * GetDeviceScaleFactorSqrt()), originalPadding.Top, originalPadding.Right, originalPadding.Bottom);
             }
         }
 
@@ -861,37 +888,37 @@ namespace ReaLTaiizor.Forms
                     break;
                 case FormStyles.ActionBar_None:
                     ACTION_BAR_HEIGHT = 0;
-                    STATUS_BAR_HEIGHT = STATUS_BAR_HEIGHT_DEFAULT;
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
                     break;
                 case FormStyles.ActionBar_40:
-                    ACTION_BAR_HEIGHT = ACTION_BAR_HEIGHT_DEFAULT;
-                    STATUS_BAR_HEIGHT = STATUS_BAR_HEIGHT_DEFAULT;
+                    ACTION_BAR_HEIGHT = (int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
                     break;
                 case FormStyles.ActionBar_48:
-                    ACTION_BAR_HEIGHT = 48;
-                    STATUS_BAR_HEIGHT = STATUS_BAR_HEIGHT_DEFAULT;
+                    ACTION_BAR_HEIGHT = (int)(48 * GetDeviceScaleFactorSqrt());
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
                     break;
                 case FormStyles.ActionBar_56:
-                    ACTION_BAR_HEIGHT = 56;
-                    STATUS_BAR_HEIGHT = STATUS_BAR_HEIGHT_DEFAULT;
+                    ACTION_BAR_HEIGHT = (int)(56 * GetDeviceScaleFactorSqrt());
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
                     break;
                 case FormStyles.ActionBar_64:
-                    ACTION_BAR_HEIGHT = 64;
-                    STATUS_BAR_HEIGHT = STATUS_BAR_HEIGHT_DEFAULT;
+                    ACTION_BAR_HEIGHT = (int)(64 * GetDeviceScaleFactorSqrt());
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
                     break;
                 default:
-                    ACTION_BAR_HEIGHT = ACTION_BAR_HEIGHT_DEFAULT;
-                    STATUS_BAR_HEIGHT = STATUS_BAR_HEIGHT_DEFAULT;
+                    ACTION_BAR_HEIGHT = (int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
                     break;
             }
 
-            Padding = new Padding(DrawerShowIconsWhenHidden ? drawerControl.MinWidth : PADDING_MINIMUM, STATUS_BAR_HEIGHT + ACTION_BAR_HEIGHT, Padding.Right, Padding.Bottom);
+            Padding = new Padding(DrawerShowIconsWhenHidden ? drawerControl.MinWidth : (int)(PADDING_MINIMUM * GetDeviceScaleFactorSqrt()), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), Padding.Right, Padding.Bottom);
             originalPadding = Padding;
 
             if (DrawerTabControl != null)
             {
-                int height = ClientSize.Height - (STATUS_BAR_HEIGHT + ACTION_BAR_HEIGHT);
-                Point location = Point.Add(Location, new Size(0, STATUS_BAR_HEIGHT + ACTION_BAR_HEIGHT));
+                int height = ClientSize.Height - ((int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
+                Point location = Point.Add(Location, new Size(0, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt())));
                 drawerOverlay.Size = new Size(ClientSize.Width, height);
                 drawerOverlay.Location = location;
                 drawerForm.Size = new Size(DrawerWidth, height);
@@ -1080,42 +1107,42 @@ namespace ReaLTaiizor.Forms
             //True if the mouse is hovering over a child control
             bool isChildUnderMouse = GetChildAtPoint(coords) != null;
 
-            if (!isChildUnderMouse && !Maximized && coords.Y < BORDER_WIDTH && coords.X > BORDER_WIDTH && coords.X < ClientSize.Width - BORDER_WIDTH)
+            if (!isChildUnderMouse && !Maximized && coords.Y < (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.X > (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.X < ClientSize.Width - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
             {
                 _resizeDir = ResizeDirection.Top;
                 Cursor = Cursors.SizeNS;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.X <= BORDER_WIDTH && coords.Y < BORDER_WIDTH)
+            else if (!isChildUnderMouse && !Maximized && coords.X <= (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.Y < (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
             {
                 _resizeDir = ResizeDirection.TopLeft;
                 Cursor = Cursors.SizeNWSE;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - BORDER_WIDTH && coords.Y < BORDER_WIDTH)
+            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.Y < (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
             {
                 _resizeDir = ResizeDirection.TopRight;
                 Cursor = Cursors.SizeNESW;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.X <= BORDER_WIDTH && coords.Y >= ClientSize.Height - BORDER_WIDTH)
+            else if (!isChildUnderMouse && !Maximized && coords.X <= (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.Y >= ClientSize.Height - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
             {
                 _resizeDir = ResizeDirection.BottomLeft;
                 Cursor = Cursors.SizeNESW;
             }
-            else if ((!isChildUnderMouse || DrawerTabControl != null) && !Maximized && coords.X <= BORDER_WIDTH)
+            else if ((!isChildUnderMouse || DrawerTabControl != null) && !Maximized && coords.X <= (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
             {
                 _resizeDir = ResizeDirection.Left;
                 Cursor = Cursors.SizeWE;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - BORDER_WIDTH && coords.Y >= ClientSize.Height - BORDER_WIDTH)
+            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.Y >= ClientSize.Height - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
             {
                 _resizeDir = ResizeDirection.BottomRight;
                 Cursor = Cursors.SizeNWSE;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - BORDER_WIDTH)
+            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
             {
                 _resizeDir = ResizeDirection.Right;
                 Cursor = Cursors.SizeWE;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.Y >= ClientSize.Height - BORDER_WIDTH)
+            else if (!isChildUnderMouse && !Maximized && coords.Y >= ClientSize.Height - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
             {
                 _resizeDir = ResizeDirection.Bottom;
                 Cursor = Cursors.SizeNS;
@@ -1305,7 +1332,7 @@ namespace ReaLTaiizor.Forms
                     g.FillRectangle(downBrush, _drawerButtonBounds);
                 }
 
-                _drawerIconRect = new Rectangle(SkinManager.FORM_PADDING / 2, STATUS_BAR_HEIGHT, ACTION_BAR_HEIGHT_DEFAULT, ACTION_BAR_HEIGHT);
+                _drawerIconRect = new Rectangle(SkinManager.FORM_PADDING / 2, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), (int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt()), (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
                 // Ripple
                 if (_clickAnimManager.IsAnimating())
                 {
@@ -1325,33 +1352,33 @@ namespace ReaLTaiizor.Forms
                 g.DrawLine(
                    formButtonsPen,
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING,
-                   _drawerIconRect.Y + (int)(ACTION_BAR_HEIGHT / 2),
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2),
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING + 18,
-                   _drawerIconRect.Y + (int)(ACTION_BAR_HEIGHT / 2));
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2));
 
                 // Bottom line
                 g.DrawLine(
                    formButtonsPen,
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING,
-                   _drawerIconRect.Y + (int)(ACTION_BAR_HEIGHT / 2) - 6,
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) - 6,
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING + 18,
-                   _drawerIconRect.Y + (int)(ACTION_BAR_HEIGHT / 2) - 6);
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) - 6);
 
                 // Top line
                 g.DrawLine(
                    formButtonsPen,
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING,
-                   _drawerIconRect.Y + (int)(ACTION_BAR_HEIGHT / 2) + 6,
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) + 6,
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING + 18,
-                   _drawerIconRect.Y + (int)(ACTION_BAR_HEIGHT / 2) + 6);
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) + 6);
             }
 
             if (ControlBox == true && FormStyle != FormStyles.ActionBar_None && FormStyle != FormStyles.StatusAndActionBar_None)
             {
                 //Form title
                 using MaterialNativeTextRenderer NativeText = new(g);
-                Rectangle textLocation = new(DrawerTabControl != null ? TITLE_LEFT_PADDING : TITLE_LEFT_PADDING - (ICON_SIZE + (ACTION_BAR_PADDING * 2)), STATUS_BAR_HEIGHT, ClientSize.Width, ACTION_BAR_HEIGHT);
-                NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6),
+                Rectangle textLocation = new(DrawerTabControl != null ? (int)(TITLE_LEFT_PADDING * GetDeviceScaleFactorSqrt()) : (int)(TITLE_LEFT_PADDING * GetDeviceScaleFactorSqrt()) - ((int)(ICON_SIZE * GetDeviceScaleFactorSqrt()) + ((int)(ACTION_BAR_PADDING * GetDeviceScaleFactorSqrt()) * 2)), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
+                NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6, GetDeviceScaleFactor()),
                     SkinManager.ColorScheme.TextColor,
                     textLocation.Location,
                     textLocation.Size,
@@ -1362,7 +1389,7 @@ namespace ReaLTaiizor.Forms
                 //Form title
                 using MaterialNativeTextRenderer NativeText = new(g);
                 Rectangle textLocation = new(10, 4, ClientSize.Width, ClientSize.Height);
-                NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2),
+                NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2, GetDeviceScaleFactor()),
                     SkinManager.ColorScheme.TextColor,
                     textLocation.Location,
                     textLocation.Size,

--- a/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
@@ -266,7 +266,7 @@ namespace ReaLTaiizor.Forms
             set => base.FormBorderStyle = value;
         }
 
-        public Rectangle UserArea => new(ClientRectangle.X, ClientRectangle.Y + (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), ClientSize.Width, ClientSize.Height - ((int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt())));
+        public Rectangle UserArea => new(ClientRectangle.X, ClientRectangle.Y + (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt), ClientSize.Width, ClientSize.Height - ((int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt)));
         #endregion
 
         #region Enums
@@ -421,12 +421,12 @@ namespace ReaLTaiizor.Forms
         private ResizeDirection _resizeDir;
         private ButtonState _buttonState = ButtonState.None;
 
-        private Rectangle _minButtonBounds => new(ClientSize.Width - (3 * (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor())), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor()), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
-        private Rectangle _maxButtonBounds => new(ClientSize.Width - (2 * (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor())), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor()), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
-        private Rectangle _xButtonBounds => new(ClientSize.Width - (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor()), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * GetDeviceScaleFactor()), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
-        private Rectangle _actionBarBounds => new(ClientRectangle.X, ClientRectangle.Y + (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
-        private Rectangle _drawerButtonBounds => new(ClientRectangle.X + (SkinManager.FORM_PADDING / 2) + 3, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + ((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) - ((int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt()) / 2), ((int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt())), (int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt()));
-        private Rectangle _statusBarBounds => new(ClientRectangle.X, ClientRectangle.Y, ClientSize.Width, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
+        private Rectangle _minButtonBounds => new(ClientSize.Width - (3 * (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor)), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt));
+        private Rectangle _maxButtonBounds => new(ClientSize.Width - (2 * (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor)), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt));
+        private Rectangle _xButtonBounds => new(ClientSize.Width - (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt));
+        private Rectangle _actionBarBounds => new(ClientRectangle.X, ClientRectangle.Y + (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt));
+        private Rectangle _drawerButtonBounds => new(ClientRectangle.X + (SkinManager.FORM_PADDING / 2) + 3, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + ((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) - ((int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt) / 2), ((int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt)), (int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt));
+        private Rectangle _statusBarBounds => new(ClientRectangle.X, ClientRectangle.Y, ClientSize.Width, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt));
         private Rectangle _drawerIconRect;
 
         private bool Maximized
@@ -462,6 +462,39 @@ namespace ReaLTaiizor.Forms
 
         private int STATUS_BAR_HEIGHT = 24;
         private int ACTION_BAR_HEIGHT = 40;
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio= SkinManager.GetDeviceScaleFactor(this);
+                }
+                return  _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt= value;
+            }
+        }
         #endregion
 
         public MaterialForm()
@@ -483,7 +516,7 @@ namespace ReaLTaiizor.Forms
             FormStyle = FormStyles.ActionBar_40;
 
             //Keep space for resize by mouse
-            Padding = new Padding((int)(PADDING_MINIMUM * GetDeviceScaleFactorSqrt()), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), (int)(PADDING_MINIMUM * GetDeviceScaleFactorSqrt()), (int)(PADDING_MINIMUM * GetDeviceScaleFactorSqrt()));
+            Padding = new Padding((int)(PADDING_MINIMUM * ScaleFactorSqrt), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt), (int)(PADDING_MINIMUM * ScaleFactorSqrt), (int)(PADDING_MINIMUM * ScaleFactorSqrt));
 
             _clickAnimManager = new AnimationManager()
             {
@@ -506,25 +539,6 @@ namespace ReaLTaiizor.Forms
 
         #region Private Methods
 
-
-
-
-        private float GetDeviceScaleFactor()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)this.DeviceDpi / 96f;
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            // Buttons are not included in sqrt controls.
-            return scalingFactor;
-        }
-
-        private float GetDeviceScaleFactorSqrt()
-        {
-            // 96 is Windows default scaling DPI（100% scale）
-            float scalingFactor = (float)Math.Sqrt((float)this.DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            return scalingFactor;
-        }
         protected void AddDrawerOverlayForm()
         {
             if (DrawerTabControl == null)
@@ -730,7 +744,7 @@ namespace ReaLTaiizor.Forms
             }
             else
             {
-                Padding = new Padding((int)(PADDING_MINIMUM * GetDeviceScaleFactorSqrt()), originalPadding.Top, originalPadding.Right, originalPadding.Bottom);
+                Padding = new Padding((int)(PADDING_MINIMUM * ScaleFactorSqrt), originalPadding.Top, originalPadding.Right, originalPadding.Bottom);
             }
         }
 
@@ -888,37 +902,37 @@ namespace ReaLTaiizor.Forms
                     break;
                 case FormStyles.ActionBar_None:
                     ACTION_BAR_HEIGHT = 0;
-                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt);
                     break;
                 case FormStyles.ActionBar_40:
-                    ACTION_BAR_HEIGHT = (int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
-                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
+                    ACTION_BAR_HEIGHT = (int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt);
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt);
                     break;
                 case FormStyles.ActionBar_48:
-                    ACTION_BAR_HEIGHT = (int)(48 * GetDeviceScaleFactorSqrt());
-                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
+                    ACTION_BAR_HEIGHT = (int)(48 * ScaleFactorSqrt);
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt);
                     break;
                 case FormStyles.ActionBar_56:
-                    ACTION_BAR_HEIGHT = (int)(56 * GetDeviceScaleFactorSqrt());
-                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
+                    ACTION_BAR_HEIGHT = (int)(56 * ScaleFactorSqrt);
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt);
                     break;
                 case FormStyles.ActionBar_64:
-                    ACTION_BAR_HEIGHT = (int)(64 * GetDeviceScaleFactorSqrt());
-                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
+                    ACTION_BAR_HEIGHT = (int)(64 * ScaleFactorSqrt);
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt);
                     break;
                 default:
-                    ACTION_BAR_HEIGHT = (int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
-                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt());
+                    ACTION_BAR_HEIGHT = (int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt);
+                    STATUS_BAR_HEIGHT = (int)(STATUS_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt);
                     break;
             }
 
-            Padding = new Padding(DrawerShowIconsWhenHidden ? drawerControl.MinWidth : (int)(PADDING_MINIMUM * GetDeviceScaleFactorSqrt()), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), Padding.Right, Padding.Bottom);
+            Padding = new Padding(DrawerShowIconsWhenHidden ? drawerControl.MinWidth : (int)(PADDING_MINIMUM * ScaleFactorSqrt), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt), Padding.Right, Padding.Bottom);
             originalPadding = Padding;
 
             if (DrawerTabControl != null)
             {
-                int height = ClientSize.Height - ((int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
-                Point location = Point.Add(Location, new Size(0, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt())));
+                int height = ClientSize.Height - ((int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt));
+                Point location = Point.Add(Location, new Size(0, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt)));
                 drawerOverlay.Size = new Size(ClientSize.Width, height);
                 drawerOverlay.Location = location;
                 drawerForm.Size = new Size(DrawerWidth, height);
@@ -930,6 +944,21 @@ namespace ReaLTaiizor.Forms
         #endregion
 
         #region WinForms Methods
+
+        protected override void OnLoad(EventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            base.OnLoad(e);
+        }
+
+        protected override void OnDpiChanged(DpiChangedEventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            Invalidate();
+            base.OnDpiChanged(e);
+        }
 
         protected override void Dispose(bool disposing)
         {
@@ -1113,42 +1142,42 @@ namespace ReaLTaiizor.Forms
             //True if the mouse is hovering over a child control
             bool isChildUnderMouse = GetChildAtPoint(coords) != null;
 
-            if (!isChildUnderMouse && !Maximized && coords.Y < (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.X > (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.X < ClientSize.Width - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
+            if (!isChildUnderMouse && !Maximized && coords.Y < (int)(BORDER_WIDTH * ScaleFactorSqrt) && coords.X > (int)(BORDER_WIDTH * ScaleFactorSqrt) && coords.X < ClientSize.Width - (int)(BORDER_WIDTH * ScaleFactorSqrt))
             {
                 _resizeDir = ResizeDirection.Top;
                 Cursor = Cursors.SizeNS;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.X <= (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.Y < (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
+            else if (!isChildUnderMouse && !Maximized && coords.X <= (int)(BORDER_WIDTH * ScaleFactorSqrt) && coords.Y < (int)(BORDER_WIDTH * ScaleFactorSqrt))
             {
                 _resizeDir = ResizeDirection.TopLeft;
                 Cursor = Cursors.SizeNWSE;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.Y < (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
+            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - (int)(BORDER_WIDTH * ScaleFactorSqrt) && coords.Y < (int)(BORDER_WIDTH * ScaleFactorSqrt))
             {
                 _resizeDir = ResizeDirection.TopRight;
                 Cursor = Cursors.SizeNESW;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.X <= (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.Y >= ClientSize.Height - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
+            else if (!isChildUnderMouse && !Maximized && coords.X <= (int)(BORDER_WIDTH * ScaleFactorSqrt) && coords.Y >= ClientSize.Height - (int)(BORDER_WIDTH * ScaleFactorSqrt))
             {
                 _resizeDir = ResizeDirection.BottomLeft;
                 Cursor = Cursors.SizeNESW;
             }
-            else if ((!isChildUnderMouse || DrawerTabControl != null) && !Maximized && coords.X <= (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
+            else if ((!isChildUnderMouse || DrawerTabControl != null) && !Maximized && coords.X <= (int)(BORDER_WIDTH * ScaleFactorSqrt))
             {
                 _resizeDir = ResizeDirection.Left;
                 Cursor = Cursors.SizeWE;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()) && coords.Y >= ClientSize.Height - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
+            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - (int)(BORDER_WIDTH * ScaleFactorSqrt) && coords.Y >= ClientSize.Height - (int)(BORDER_WIDTH * ScaleFactorSqrt))
             {
                 _resizeDir = ResizeDirection.BottomRight;
                 Cursor = Cursors.SizeNWSE;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
+            else if (!isChildUnderMouse && !Maximized && coords.X >= ClientSize.Width - (int)(BORDER_WIDTH * ScaleFactorSqrt))
             {
                 _resizeDir = ResizeDirection.Right;
                 Cursor = Cursors.SizeWE;
             }
-            else if (!isChildUnderMouse && !Maximized && coords.Y >= ClientSize.Height - (int)(BORDER_WIDTH * GetDeviceScaleFactorSqrt()))
+            else if (!isChildUnderMouse && !Maximized && coords.Y >= ClientSize.Height - (int)(BORDER_WIDTH * ScaleFactorSqrt))
             {
                 _resizeDir = ResizeDirection.Bottom;
                 Cursor = Cursors.SizeNS;
@@ -1338,7 +1367,7 @@ namespace ReaLTaiizor.Forms
                     g.FillRectangle(downBrush, _drawerButtonBounds);
                 }
 
-                _drawerIconRect = new Rectangle(SkinManager.FORM_PADDING / 2, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), (int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt()), (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
+                _drawerIconRect = new Rectangle(SkinManager.FORM_PADDING / 2, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt), (int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt), (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt));
                 // Ripple
                 if (_clickAnimManager.IsAnimating())
                 {
@@ -1358,33 +1387,33 @@ namespace ReaLTaiizor.Forms
                 g.DrawLine(
                    formButtonsPen,
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2),
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2),
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING + 18,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2));
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2));
 
                 // Bottom line
                 g.DrawLine(
                    formButtonsPen,
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) - 6,
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) - 6,
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING + 18,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) - 6);
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) - 6);
 
                 // Top line
                 g.DrawLine(
                    formButtonsPen,
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) + 6,
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) + 6,
                    _drawerIconRect.X + (int)SkinManager.FORM_PADDING + 18,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) + 6);
+                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) + 6);
             }
 
             if (ControlBox == true && FormStyle != FormStyles.ActionBar_None && FormStyle != FormStyles.StatusAndActionBar_None)
             {
                 //Form title
                 using MaterialNativeTextRenderer NativeText = new(g);
-                var font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6, GetDeviceScaleFactor());
-                Rectangle textLocation = new(DrawerTabControl != null ? (int)(TITLE_LEFT_PADDING * GetDeviceScaleFactorSqrt()) : (int)(TITLE_LEFT_PADDING * GetDeviceScaleFactorSqrt()) - ((int)(ICON_SIZE * GetDeviceScaleFactorSqrt()) + ((int)(ACTION_BAR_PADDING * GetDeviceScaleFactorSqrt()) * 2)), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
+                var font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6, ScaleFactor);
+                Rectangle textLocation = new(DrawerTabControl != null ? (int)(TITLE_LEFT_PADDING * ScaleFactorSqrt) : (int)(TITLE_LEFT_PADDING * ScaleFactorSqrt) - ((int)(ICON_SIZE * ScaleFactorSqrt) + ((int)(ACTION_BAR_PADDING * ScaleFactorSqrt) * 2)), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt));
                 NativeText.DrawTransparentText(Text, font,
                     SkinManager.ColorScheme.TextColor,
                     textLocation.Location,
@@ -1395,7 +1424,7 @@ namespace ReaLTaiizor.Forms
             {
                 //Form title
                 using MaterialNativeTextRenderer NativeText = new(g);
-                var font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2, GetDeviceScaleFactor());
+                var font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2, ScaleFactor);
                 Rectangle textLocation = new(10, 4, ClientSize.Width, ClientSize.Height);
                 NativeText.DrawTransparentText(Text, font,
                     SkinManager.ColorScheme.TextColor,
@@ -1465,8 +1494,6 @@ namespace ReaLTaiizor.Forms
         [DllImport("user32.dll")]
         private static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
 
-        [DllImport("gdi32.dll", ExactSpelling = true)]
-        private static extern bool DeleteObject(IntPtr hObject);
         #endregion
     }
 

--- a/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Drawing.Text;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -87,6 +88,9 @@ namespace ReaLTaiizor.Forms
             }
         }
 
+        /// <summary>
+        /// This num is DPI-aware
+        /// </summary>
         [Category("Drawer")]
         public int DrawerWidth { get; set; }
 
@@ -413,6 +417,14 @@ namespace ReaLTaiizor.Forms
         private const int TITLE_LEFT_PADDING = 72;
         private const int ACTION_BAR_PADDING = 16;
         private const int ACTION_BAR_HEIGHT_DEFAULT = 40;
+
+        // Drawer (hamburger) icon specs – logical units
+        // DO NOT USE MAGIC NUMS
+        private const float DRAWER_LINE_THICKNESS = 2f;
+        private const int DRAWER_LINE_COUNT = 3;
+        private const int DRAWER_LINE_SPACING = 6;     // vertical distance between lines
+        private const int DRAWER_LINE_LENGTH = 18;     // line width
+
         #endregion
 
         #region Private Fields
@@ -425,7 +437,7 @@ namespace ReaLTaiizor.Forms
         private Rectangle _maxButtonBounds => new(ClientSize.Width - (2 * (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor)), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt));
         private Rectangle _xButtonBounds => new(ClientSize.Width - (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt));
         private Rectangle _actionBarBounds => new(ClientRectangle.X, ClientRectangle.Y + (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt));
-        private Rectangle _drawerButtonBounds => new(ClientRectangle.X + (SkinManager.FORM_PADDING / 2) + 3, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + ((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) - ((int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt) / 2), ((int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt)), (int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt));
+        private Rectangle _drawerButtonBounds => new(ClientRectangle.X + (int)(SkinManager.FORM_PADDING * ScaleFactor / 2) + 3, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + ((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) - ((int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt) / 2), ((int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactor)), (int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt));
         private Rectangle _statusBarBounds => new(ClientRectangle.X, ClientRectangle.Y, ClientSize.Width, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt));
         private Rectangle _drawerIconRect;
 
@@ -605,7 +617,7 @@ namespace ReaLTaiizor.Forms
             drawerForm.ControlBox = false;
             drawerForm.FormBorderStyle = FormBorderStyle.None;
             drawerForm.Visible = true;
-            drawerForm.Size = new Size(DrawerWidth, H);
+            drawerForm.Size = new Size((int)(DrawerWidth * ScaleFactor), H);
             drawerForm.Location = new Point(PointToScreen(Point.Empty).X, Y);
             drawerForm.ShowInTaskbar = false;
             drawerForm.Owner = this; //drawerOverlay
@@ -615,7 +627,7 @@ namespace ReaLTaiizor.Forms
             // Add drawer to overlay form
             drawerForm.Controls.Add(drawerControl);
             drawerControl.Location = new Point(0, 0);
-            drawerControl.Size = new Size(DrawerWidth, H);
+            drawerControl.Size = new Size((int)(DrawerWidth * ScaleFactor), H);
             drawerControl.Anchor = AnchorStyles.Top | AnchorStyles.Bottom;
             drawerControl.BaseTabControl = DrawerTabControl;
             drawerControl.DrawerHideTabName = DrawerHideTabName;
@@ -651,7 +663,7 @@ namespace ReaLTaiizor.Forms
             Resize += (sender, e) =>
             {
                 H = ClientSize.Height - _statusBarBounds.Height - _actionBarBounds.Height;
-                drawerForm.Size = new Size(DrawerWidth, H);
+                drawerForm.Size = new Size((int)(DrawerWidth * ScaleFactor), H);
                 drawerOverlay.Size = new Size(ClientSize.Width, H);
             };
 
@@ -665,6 +677,10 @@ namespace ReaLTaiizor.Forms
             // Close when click outside menu
             drawerOverlay.Click += (sender, e) =>
             {
+                drawerOverlay.TopMost = false;
+                drawerForm.TopMost = true;
+                drawerForm.TopMost = TopMost;
+                // 3 lines above is to make sure overlay not cover drawerForm after focused once.
                 drawerControl.Hide();
             };
 
@@ -935,7 +951,7 @@ namespace ReaLTaiizor.Forms
                 Point location = Point.Add(Location, new Size(0, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt)));
                 drawerOverlay.Size = new Size(ClientSize.Width, height);
                 drawerOverlay.Location = location;
-                drawerForm.Size = new Size(DrawerWidth, height);
+                drawerForm.Size = new Size((int)(DrawerWidth * ScaleFactor), height);
                 drawerForm.Location = location;
             }
 
@@ -1207,6 +1223,12 @@ namespace ReaLTaiizor.Forms
             ReleaseCapture();
         }
 
+        protected override void OnResize(EventArgs e)
+        {
+            RecalculateFormBoundaries();
+            base.OnResize(e);
+        }
+
         protected override void OnPaint(PaintEventArgs e)
         {
             Brush hoverBrush = SkinManager.BackgroundHoverBrush;
@@ -1367,7 +1389,7 @@ namespace ReaLTaiizor.Forms
                     g.FillRectangle(downBrush, _drawerButtonBounds);
                 }
 
-                _drawerIconRect = new Rectangle(SkinManager.FORM_PADDING / 2, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt), (int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt), (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt));
+                _drawerIconRect = new Rectangle((int)(SkinManager.FORM_PADDING * ScaleFactor / 2), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt), (int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactor), (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt));
                 // Ripple
                 if (_clickAnimManager.IsAnimating())
                 {
@@ -1382,30 +1404,38 @@ namespace ReaLTaiizor.Forms
                     rippleBrush.Dispose();
                 }
 
-                using Pen formButtonsPen = new(SkinManager.ColorScheme.TextColor, 2);
-                // Middle line
-                g.DrawLine(
-                   formButtonsPen,
-                   _drawerIconRect.X + (int)SkinManager.FORM_PADDING,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2),
-                   _drawerIconRect.X + (int)SkinManager.FORM_PADDING + 18,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2));
+                using Pen drawerPen = new(
+                    SkinManager.ColorScheme.TextColor,
+                    DRAWER_LINE_THICKNESS * ScaleFactorSqrt);
 
-                // Bottom line
-                g.DrawLine(
-                   formButtonsPen,
-                   _drawerIconRect.X + (int)SkinManager.FORM_PADDING,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) - 6,
-                   _drawerIconRect.X + (int)SkinManager.FORM_PADDING + 18,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) - 6);
+                drawerPen.StartCap = LineCap.Round;
+                drawerPen.EndCap = LineCap.Round;
 
-                // Top line
-                g.DrawLine(
-                   formButtonsPen,
-                   _drawerIconRect.X + (int)SkinManager.FORM_PADDING,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) + 6,
-                   _drawerIconRect.X + (int)SkinManager.FORM_PADDING + 18,
-                   _drawerIconRect.Y + (int)((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) + 6);
+                // X basic
+                int startX = _drawerIconRect.X + (int)(SkinManager.FORM_PADDING * ScaleFactor);
+                int endX = startX + (int)(DRAWER_LINE_LENGTH * ScaleFactorSqrt);
+
+                // Y center
+                int centerY = _drawerIconRect.Y
+                    + (int)((ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2);
+
+                // Total Height = (nums - 1) * space
+                int totalHeight =
+                    (DRAWER_LINE_COUNT - 1)
+                    * (int)(DRAWER_LINE_SPACING * ScaleFactorSqrt);
+
+                // First Y
+                int firstLineY = centerY - totalHeight / 2;
+
+                // Draw lines
+                for (int i = 0; i < DRAWER_LINE_COUNT; i++)
+                {
+                    int y = firstLineY
+                        + i * (int)(DRAWER_LINE_SPACING * ScaleFactorSqrt);
+
+                    g.DrawLine(drawerPen, startX, y, endX, y);
+                }
+
             }
 
             if (ControlBox == true && FormStyle != FormStyles.ActionBar_None && FormStyle != FormStyles.StatusAndActionBar_None)
@@ -1413,7 +1443,7 @@ namespace ReaLTaiizor.Forms
                 //Form title
                 using MaterialNativeTextRenderer NativeText = new(g);
                 var font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6, ScaleFactor);
-                Rectangle textLocation = new(DrawerTabControl != null ? (int)(TITLE_LEFT_PADDING * ScaleFactorSqrt) : (int)(TITLE_LEFT_PADDING * ScaleFactorSqrt) - ((int)(ICON_SIZE * ScaleFactorSqrt) + ((int)(ACTION_BAR_PADDING * ScaleFactorSqrt) * 2)), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt));
+                Rectangle textLocation = new(DrawerTabControl != null ? (int)(TITLE_LEFT_PADDING * ScaleFactor) : (int)(TITLE_LEFT_PADDING * ScaleFactor) - ((int)(ICON_SIZE * ScaleFactor) + ((int)(ACTION_BAR_PADDING * ScaleFactor) * 2)), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt));
                 NativeText.DrawTransparentText(Text, font,
                     SkinManager.ColorScheme.TextColor,
                     textLocation.Location,

--- a/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
@@ -30,8 +30,8 @@ namespace ReaLTaiizor.Forms
         /// <summary>
         /// Indicate if the form should respond to System Dpi Scaling Ratio
         /// </summary>
-        [DefaultValue(true)]
-        public bool ScalingAware { get; set; } = true;
+        //[DefaultValue(true)]
+        //public bool ScalingAware { get; set; } = true;
 
         [Browsable(false)]
         public int Depth { get; set; }
@@ -428,6 +428,7 @@ namespace ReaLTaiizor.Forms
         private Rectangle _drawerButtonBounds => new(ClientRectangle.X + (SkinManager.FORM_PADDING / 2) + 3, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) + ((int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()) / 2) - ((int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt()) / 2), ((int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt())), (int)(ACTION_BAR_HEIGHT_DEFAULT * GetDeviceScaleFactorSqrt()));
         private Rectangle _statusBarBounds => new(ClientRectangle.X, ClientRectangle.Y, ClientSize.Width, (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
         private Rectangle _drawerIconRect;
+        private List<IntPtr> LFontToBeReleased = new List<IntPtr>();
 
         private bool Maximized
         {
@@ -930,6 +931,24 @@ namespace ReaLTaiizor.Forms
         #endregion
 
         #region WinForms Methods
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Release handle from CreateFont / LogFont
+                foreach (IntPtr handle in LFontToBeReleased)
+                {
+                    if (handle != IntPtr.Zero)
+                    {
+                        DeleteObject(handle);
+                    }
+                }
+                LFontToBeReleased.Clear();
+            }
+            base.Dispose(disposing);
+        }
+
         protected override CreateParams CreateParams
         {
             get
@@ -1377,8 +1396,10 @@ namespace ReaLTaiizor.Forms
             {
                 //Form title
                 using MaterialNativeTextRenderer NativeText = new(g);
+                var font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6, GetDeviceScaleFactor());
+                LFontToBeReleased.Add(font);
                 Rectangle textLocation = new(DrawerTabControl != null ? (int)(TITLE_LEFT_PADDING * GetDeviceScaleFactorSqrt()) : (int)(TITLE_LEFT_PADDING * GetDeviceScaleFactorSqrt()) - ((int)(ICON_SIZE * GetDeviceScaleFactorSqrt()) + ((int)(ACTION_BAR_PADDING * GetDeviceScaleFactorSqrt()) * 2)), (int)(STATUS_BAR_HEIGHT * GetDeviceScaleFactorSqrt()), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * GetDeviceScaleFactorSqrt()));
-                NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6, GetDeviceScaleFactor()),
+                NativeText.DrawTransparentText(Text, font,
                     SkinManager.ColorScheme.TextColor,
                     textLocation.Location,
                     textLocation.Size,
@@ -1388,8 +1409,10 @@ namespace ReaLTaiizor.Forms
             {
                 //Form title
                 using MaterialNativeTextRenderer NativeText = new(g);
+                var font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2, GetDeviceScaleFactor());
+                LFontToBeReleased.Add(font);
                 Rectangle textLocation = new(10, 4, ClientSize.Width, ClientSize.Height);
-                NativeText.DrawTransparentText(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2, GetDeviceScaleFactor()),
+                NativeText.DrawTransparentText(Text, font,
                     SkinManager.ColorScheme.TextColor,
                     textLocation.Location,
                     textLocation.Size,
@@ -1456,6 +1479,9 @@ namespace ReaLTaiizor.Forms
 
         [DllImport("user32.dll")]
         private static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
+
+        [DllImport("gdi32.dll", ExactSpelling = true)]
+        private static extern bool DeleteObject(IntPtr hObject);
         #endregion
     }
 

--- a/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
@@ -437,7 +437,7 @@ namespace ReaLTaiizor.Forms
         private Rectangle _maxButtonBounds => new(ClientSize.Width - (2 * (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor)), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt));
         private Rectangle _xButtonBounds => new(ClientSize.Width - (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor), ClientRectangle.Y, (int)(STATUS_BAR_BUTTON_WIDTH * ScaleFactor), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt));
         private Rectangle _actionBarBounds => new(ClientRectangle.X, ClientRectangle.Y + (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt));
-        private Rectangle _drawerButtonBounds => new(ClientRectangle.X + (int)(SkinManager.FORM_PADDING * ScaleFactor / 2) + 3, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + ((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) - ((int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt) / 2), ((int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactor)), (int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt));
+        private Rectangle _drawerButtonBounds => new(ClientRectangle.X + (int)(SkinManager.FORM_PADDING * ScaleFactor / 2) + 3, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt) + ((int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2) - ((int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt) / 2), (int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactor), (int)(ACTION_BAR_HEIGHT_DEFAULT * ScaleFactorSqrt));
         private Rectangle _statusBarBounds => new(ClientRectangle.X, ClientRectangle.Y, ClientSize.Width, (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt));
         private Rectangle _drawerIconRect;
 
@@ -482,9 +482,9 @@ namespace ReaLTaiizor.Forms
             {
                 if (!_scaleRatio.HasValue)
                 {
-                    _scaleRatio= SkinManager.GetDeviceScaleFactor(this);
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
                 }
-                return  _scaleRatio.Value;
+                return _scaleRatio.Value;
             }
             set
             {
@@ -504,7 +504,7 @@ namespace ReaLTaiizor.Forms
             }
             set
             {
-                _scaleRatioSqrt= value;
+                _scaleRatioSqrt = value;
             }
         }
         #endregion
@@ -1417,7 +1417,7 @@ namespace ReaLTaiizor.Forms
 
                 // Y center
                 int centerY = _drawerIconRect.Y
-                    + (int)((ACTION_BAR_HEIGHT * ScaleFactorSqrt) / 2);
+                    + (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt / 2);
 
                 // Total Height = (nums - 1) * space
                 int totalHeight =
@@ -1425,13 +1425,13 @@ namespace ReaLTaiizor.Forms
                     * (int)(DRAWER_LINE_SPACING * ScaleFactorSqrt);
 
                 // First Y
-                int firstLineY = centerY - totalHeight / 2;
+                int firstLineY = centerY - (totalHeight / 2);
 
                 // Draw lines
                 for (int i = 0; i < DRAWER_LINE_COUNT; i++)
                 {
                     int y = firstLineY
-                        + i * (int)(DRAWER_LINE_SPACING * ScaleFactorSqrt);
+                        + (i * (int)(DRAWER_LINE_SPACING * ScaleFactorSqrt));
 
                     g.DrawLine(drawerPen, startX, y, endX, y);
                 }
@@ -1442,7 +1442,7 @@ namespace ReaLTaiizor.Forms
             {
                 //Form title
                 using MaterialNativeTextRenderer NativeText = new(g);
-                var font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6, ScaleFactor);
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.H6, ScaleFactor);
                 Rectangle textLocation = new(DrawerTabControl != null ? (int)(TITLE_LEFT_PADDING * ScaleFactor) : (int)(TITLE_LEFT_PADDING * ScaleFactor) - ((int)(ICON_SIZE * ScaleFactor) + ((int)(ACTION_BAR_PADDING * ScaleFactor) * 2)), (int)(STATUS_BAR_HEIGHT * ScaleFactorSqrt), ClientSize.Width, (int)(ACTION_BAR_HEIGHT * ScaleFactorSqrt));
                 NativeText.DrawTransparentText(Text, font,
                     SkinManager.ColorScheme.TextColor,
@@ -1454,7 +1454,7 @@ namespace ReaLTaiizor.Forms
             {
                 //Form title
                 using MaterialNativeTextRenderer NativeText = new(g);
-                var font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2, ScaleFactor);
+                IntPtr font = SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Subtitle2, ScaleFactor);
                 Rectangle textLocation = new(10, 4, ClientSize.Width, ClientSize.Height);
                 NativeText.DrawTransparentText(Text, font,
                     SkinManager.ColorScheme.TextColor,

--- a/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialForm.cs
@@ -486,10 +486,8 @@ namespace ReaLTaiizor.Forms
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -502,10 +500,8 @@ namespace ReaLTaiizor.Forms
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
         #endregion
 

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -344,7 +344,7 @@ namespace ReaLTaiizor.Manager
                 if (logicalFonts.TryGetValue(key, out var h))
                     return h;
                 var hOriginalFont = GetTextBoxFontBySize(size);
-                if (scaleRatio == 1) return hOriginalFont;
+                if (scaleKey == 100) return hOriginalFont;
                 LogFont lf = new LogFont();
                 if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
                 {
@@ -456,8 +456,6 @@ namespace ReaLTaiizor.Manager
         {
             // 96 is Windows default scaling DPI（100% scale）
             float scalingFactor = (float)control.DeviceDpi / 96f;
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
-            // Buttons are not included in sqrt controls.
             return scalingFactor;
         }
 
@@ -465,7 +463,7 @@ namespace ReaLTaiizor.Manager
         {
             // 96 is Windows default scaling DPI（100% scale）
             float scalingFactor = (float)Math.Sqrt((float)control.DeviceDpi / 96f);
-            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            // Since a 'replace' to code will lead to operate scaling twice in some scenes, this method provide the sqrt value of a factor.
             return scalingFactor;
         }
 

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -329,6 +329,18 @@ namespace ReaLTaiizor.Manager
             return logicalFonts[name];
         }
 
+        public IntPtr GetTextBoxFontBySize(int size, float scaleRatio)
+        {
+            var hOriginalFont = GetTextBoxFontBySize(size);
+            if (scaleRatio == 1) return hOriginalFont;
+            LogFont lf = new LogFont();
+            if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
+            {
+                return IntPtr.Zero; // Failed fetching handle
+            }
+            return createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(), lf.lfWeight), lfItalic: lf.lfItalic);
+        }
+
         public IntPtr GetLogFontByType(FontType type)
         {
             return logicalFonts[System.Enum.GetName(typeof(FontType), type)];

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -383,7 +383,7 @@ namespace ReaLTaiizor.Manager
                     return cachedFont;
                 }
                 IntPtr hOriginalFont = logicalFonts[System.Enum.GetName(typeof(FontType), type)];
-                if (scaleRatio == 1)
+                if (Math.Abs(scaleRatio - 1f) < 0.0001f)
                 {
                     return hOriginalFont;
                 }

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -452,6 +452,23 @@ namespace ReaLTaiizor.Manager
             }
         }
 
+        public float GetDeviceScaleFactor(Control control)
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)control.DeviceDpi / 96f;
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            // Buttons are not included in sqrt controls.
+            return scalingFactor;
+        }
+
+        public float GetDeviceScaleFactorSqrt(Control control)
+        {
+            // 96 is Windows default scaling DPI（100% scale）
+            float scalingFactor = (float)Math.Sqrt((float)control.DeviceDpi / 96f);
+            // Since a 'replace' to code will lead to operate scaling twice, this method provide the sqrt value of a factor.
+            return scalingFactor;
+        }
+
         private void UpdateControlBackColor(Control controlToUpdate, Color newBackColor)
         {
             // No control

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -397,14 +397,16 @@ namespace ReaLTaiizor.Manager
                     return hOriginalFont;
                 }
 
-                LogFont lf = new();
-                if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
+                using (Font originalFont = Font.FromHfont(hOriginalFont))
                 {
-                    return IntPtr.Zero; // Failed fetching handle
+                    float newSize = originalFont.Size * (float)scaleRatio;
+                    using (Font scaledFont = new Font(originalFont.FontFamily, newSize, originalFont.Style, originalFont.Unit))
+                    {
+                        IntPtr createdFont = scaledFont.ToHfont();
+                        logicalFonts.Add(key, createdFont);
+                        return createdFont;
+                    }
                 }
-                IntPtr createdFont = createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(), lf.lfWeight), lfItalic: lf.lfItalic);
-                logicalFonts.Add(key, createdFont);
-                return createdFont;
             }
         }
 

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -354,16 +354,12 @@ namespace ReaLTaiizor.Manager
 
                 try
                 {
-                    using (Font originalFont = Font.FromHfont(hOriginalFont))
-                    {
-                        float scaledSize = originalFont.Size * (float)scaleRatio;
-                        using (Font scaledFont = new Font(originalFont.FontFamily, scaledSize, originalFont.Style, originalFont.Unit))
-                        {
-                            IntPtr createdFont = scaledFont.ToHfont();
-                            logicalFonts.Add(key, createdFont);
-                            return createdFont;
-                        }
-                    }
+                    using Font originalFont = Font.FromHfont(hOriginalFont);
+                    float scaledSize = originalFont.Size * (float)scaleRatio;
+                    using Font scaledFont = new(originalFont.FontFamily, scaledSize, originalFont.Style, originalFont.Unit);
+                    IntPtr createdFont = scaledFont.ToHfont();
+                    logicalFonts.Add(key, createdFont);
+                    return createdFont;
                 }
                 catch
                 {
@@ -397,16 +393,12 @@ namespace ReaLTaiizor.Manager
                     return hOriginalFont;
                 }
 
-                using (Font originalFont = Font.FromHfont(hOriginalFont))
-                {
-                    float newSize = originalFont.Size * (float)scaleRatio;
-                    using (Font scaledFont = new Font(originalFont.FontFamily, newSize, originalFont.Style, originalFont.Unit))
-                    {
-                        IntPtr createdFont = scaledFont.ToHfont();
-                        logicalFonts.Add(key, createdFont);
-                        return createdFont;
-                    }
-                }
+                using Font originalFont = Font.FromHfont(hOriginalFont);
+                float newSize = originalFont.Size * (float)scaleRatio;
+                using Font scaledFont = new(originalFont.FontFamily, newSize, originalFont.Style, originalFont.Unit);
+                IntPtr createdFont = scaledFont.ToHfont();
+                logicalFonts.Add(key, createdFont);
+                return createdFont;
             }
         }
 

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -352,14 +352,23 @@ namespace ReaLTaiizor.Manager
                     return hOriginalFont;
                 }
 
-                LogFont lf = new();
-                if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
+                try
                 {
-                    return IntPtr.Zero; // Failed fetching handle
+                    using (Font originalFont = Font.FromHfont(hOriginalFont))
+                    {
+                        float scaledSize = originalFont.Size * (float)scaleRatio;
+                        using (Font scaledFont = new Font(originalFont.FontFamily, scaledSize, originalFont.Style, originalFont.Unit))
+                        {
+                            IntPtr createdFont = scaledFont.ToHfont();
+                            logicalFonts.Add(key, createdFont);
+                            return createdFont;
+                        }
+                    }
                 }
-                IntPtr createdFont = createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(), lf.lfWeight), lfItalic: lf.lfItalic);
-                logicalFonts.Add(key, createdFont);
-                return createdFont;
+                catch
+                {
+                    return IntPtr.Zero; // Failed fetching handle or creating scaled font
+                }
             }
         }
 

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -365,12 +365,16 @@ namespace ReaLTaiizor.Manager
         {
             int scaleKey = (int)Math.Round(scaleRatio * 100);
             string key = System.Enum.GetName(typeof(FontType), type) + "-scale" + scaleKey;
-            if (logicalFonts.ContainsKey(key))
+            if (logicalFonts.TryGetValue(key, out var existingFont))
             {
-                return logicalFonts[key];
+                return existingFont;
             }
             lock (_fontLock)
             {
+                if (logicalFonts.TryGetValue(key, out var cachedFont))
+                {
+                    return cachedFont;
+                }
                 var hOriginalFont = logicalFonts[System.Enum.GetName(typeof(FontType), type)];
                 if (scaleRatio == 1) return hOriginalFont;
                 LogFont lf = new LogFont();

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -13,7 +13,6 @@ using System.Drawing.Text;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
-using static ReaLTaiizor.Util.MaterialNativeTextRenderer;
 
 #endregion
 

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -342,10 +342,17 @@ namespace ReaLTaiizor.Manager
             lock (_fontLock)
             {
                 if (logicalFonts.TryGetValue(key, out IntPtr h))
+                {
                     return h;
+                }
+
                 IntPtr hOriginalFont = GetTextBoxFontBySize(size);
-                if (scaleKey == 100) return hOriginalFont;
-                LogFont lf = new LogFont();
+                if (scaleKey == 100)
+                {
+                    return hOriginalFont;
+                }
+
+                LogFont lf = new();
                 if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
                 {
                     return IntPtr.Zero; // Failed fetching handle
@@ -376,8 +383,12 @@ namespace ReaLTaiizor.Manager
                     return cachedFont;
                 }
                 IntPtr hOriginalFont = logicalFonts[System.Enum.GetName(typeof(FontType), type)];
-                if (scaleRatio == 1) return hOriginalFont;
-                LogFont lf = new LogFont();
+                if (scaleRatio == 1)
+                {
+                    return hOriginalFont;
+                }
+
+                LogFont lf = new();
                 if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
                 {
                     return IntPtr.Zero; // Failed fetching handle

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -37,6 +37,8 @@ namespace ReaLTaiizor.Manager
 
         public int FORM_PADDING = 14;
 
+        private readonly object _fontLock = new(); // To avoid cross-thread unexpected behaviour.
+
         // Constructor
         private MaterialSkinManager()
         {
@@ -62,7 +64,7 @@ namespace ReaLTaiizor.Manager
             }
 
             // create and save font handles for GDI
-            logicalFonts = new Dictionary<string, IntPtr>(18)
+            logicalFonts = new Dictionary<string, IntPtr>()
             {
                 { "H1", createLogicalFont("Roboto Light", 96, MaterialNativeTextRenderer.logFontWeight.FW_LIGHT) },
                 { "H2", createLogicalFont("Roboto Light", 60, MaterialNativeTextRenderer.logFontWeight.FW_LIGHT) },
@@ -331,14 +333,27 @@ namespace ReaLTaiizor.Manager
 
         public IntPtr GetTextBoxFontBySize(int size, float scaleRatio)
         {
-            var hOriginalFont = GetTextBoxFontBySize(size);
-            if (scaleRatio == 1) return hOriginalFont;
-            LogFont lf = new LogFont();
-            if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
+            int scaleKey = (int)Math.Round(scaleRatio * 100);
+            string key = "textBox" + Math.Min(16, Math.Max(12, size)).ToString() + "-scale" + scaleKey;
+            if (logicalFonts.ContainsKey(key))
             {
-                return IntPtr.Zero; // Failed fetching handle
+                return logicalFonts[key];
             }
-            return createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(), lf.lfWeight), lfItalic: lf.lfItalic);
+            lock (_fontLock)
+            {
+                if (logicalFonts.TryGetValue(key, out var h))
+                    return h;
+                var hOriginalFont = GetTextBoxFontBySize(size);
+                if (scaleRatio == 1) return hOriginalFont;
+                LogFont lf = new LogFont();
+                if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
+                {
+                    return IntPtr.Zero; // Failed fetching handle
+                }
+                IntPtr createdFont = createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(), lf.lfWeight), lfItalic: lf.lfItalic);
+                logicalFonts.Add(key, createdFont);
+                return createdFont;
+            }
         }
 
         public IntPtr GetLogFontByType(FontType type)
@@ -348,15 +363,25 @@ namespace ReaLTaiizor.Manager
 
         public IntPtr GetLogFontByType(FontType type, float scaleRatio)
         {
-            var hOriginalFont = logicalFonts[System.Enum.GetName(typeof(FontType), type)];
-            if (scaleRatio == 1) return hOriginalFont;
-            LogFont lf = new LogFont();
-            if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
+            int scaleKey = (int)Math.Round(scaleRatio * 100);
+            string key = System.Enum.GetName(typeof(FontType), type) + "-scale" + scaleKey;
+            if (logicalFonts.ContainsKey(key))
             {
-                return IntPtr.Zero; // Failed fetching handle
+                return logicalFonts[key];
             }
-            return createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(),lf.lfWeight), lfItalic:lf.lfItalic);
-            
+            lock (_fontLock)
+            {
+                var hOriginalFont = logicalFonts[System.Enum.GetName(typeof(FontType), type)];
+                if (scaleRatio == 1) return hOriginalFont;
+                LogFont lf = new LogFont();
+                if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
+                {
+                    return IntPtr.Zero; // Failed fetching handle
+                }
+                IntPtr createdFont = createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(), lf.lfWeight), lfItalic: lf.lfItalic);
+                logicalFonts.Add(key, createdFont);
+                return createdFont;
+            }
         }
         
         // Font stuff

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -335,9 +335,9 @@ namespace ReaLTaiizor.Manager
         {
             int scaleKey = (int)Math.Round(scaleRatio * 100);
             string key = "textBox" + Math.Min(16, Math.Max(12, size)).ToString() + "-scale" + scaleKey;
-            if (logicalFonts.ContainsKey(key))
+            if (logicalFonts.TryGetValue(key, out var existingFont))
             {
-                return logicalFonts[key];
+                return existingFont;
             }
             lock (_fontLock)
             {

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -409,11 +409,6 @@ namespace ReaLTaiizor.Manager
 
         private PrivateFontCollection privateFontCollection = new();
 
-        [DllImport("gdi32.dll", CharSet = CharSet.Auto)]
-        public static extern int GetObject(IntPtr hFont, int nSize, [In, Out] LogFont lf);
-
-
-
         private void addFont(byte[] fontdata)
         {
             // Add font to system table in memory

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -13,6 +13,7 @@ using System.Drawing.Text;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using static ReaLTaiizor.Util.MaterialNativeTextRenderer;
 
 #endregion
 
@@ -297,23 +298,28 @@ namespace ReaLTaiizor.Manager
 
         public Font GetFontByType(FontType type)
         {
+            return GetFontByType(type, 1);
+        }
+
+        public Font GetFontByType(FontType type, float scaleRatio)
+        {
             return type switch
             {
-                FontType.H1 => new Font(RobotoFontFamilies["Roboto_Light"], 96f, FontStyle.Regular, GraphicsUnit.Pixel),
-                FontType.H2 => new Font(RobotoFontFamilies["Roboto_Light"], 60f, FontStyle.Regular, GraphicsUnit.Pixel),
-                FontType.H3 => new Font(RobotoFontFamilies["Roboto"], 48f, FontStyle.Bold, GraphicsUnit.Pixel),
-                FontType.H4 => new Font(RobotoFontFamilies["Roboto"], 34f, FontStyle.Bold, GraphicsUnit.Pixel),
-                FontType.H5 => new Font(RobotoFontFamilies["Roboto"], 24f, FontStyle.Bold, GraphicsUnit.Pixel),
-                FontType.H6 => new Font(RobotoFontFamilies["Roboto_Medium"], 20f, FontStyle.Bold, GraphicsUnit.Pixel),
-                FontType.Subtitle1 => new Font(RobotoFontFamilies["Roboto"], 16f, FontStyle.Regular, GraphicsUnit.Pixel),
-                FontType.Subtitle2 => new Font(RobotoFontFamilies["Roboto_Medium"], 14f, FontStyle.Bold, GraphicsUnit.Pixel),
-                FontType.SubtleEmphasis => new Font(RobotoFontFamilies["Roboto"], 12f, FontStyle.Italic, GraphicsUnit.Pixel),
-                FontType.Body1 => new Font(RobotoFontFamilies["Roboto"], 14f, FontStyle.Regular, GraphicsUnit.Pixel),
-                FontType.Body2 => new Font(RobotoFontFamilies["Roboto"], 12f, FontStyle.Regular, GraphicsUnit.Pixel),
-                FontType.Button => new Font(RobotoFontFamilies["Roboto"], 14f, FontStyle.Bold, GraphicsUnit.Pixel),
-                FontType.Caption => new Font(RobotoFontFamilies["Roboto"], 12f, FontStyle.Regular, GraphicsUnit.Pixel),
-                FontType.Overline => new Font(RobotoFontFamilies["Roboto"], 10f, FontStyle.Regular, GraphicsUnit.Pixel),
-                _ => new Font(RobotoFontFamilies["Roboto"], 14f, FontStyle.Regular, GraphicsUnit.Pixel),
+                FontType.H1 => new Font(RobotoFontFamilies["Roboto_Light"], 96f * scaleRatio, FontStyle.Regular, GraphicsUnit.Pixel),
+                FontType.H2 => new Font(RobotoFontFamilies["Roboto_Light"], 60f * scaleRatio, FontStyle.Regular, GraphicsUnit.Pixel),
+                FontType.H3 => new Font(RobotoFontFamilies["Roboto"], 48f * scaleRatio, FontStyle.Bold, GraphicsUnit.Pixel),
+                FontType.H4 => new Font(RobotoFontFamilies["Roboto"], 34f * scaleRatio, FontStyle.Bold, GraphicsUnit.Pixel),
+                FontType.H5 => new Font(RobotoFontFamilies["Roboto"], 24f * scaleRatio, FontStyle.Bold, GraphicsUnit.Pixel),
+                FontType.H6 => new Font(RobotoFontFamilies["Roboto_Medium"], 20f * scaleRatio, FontStyle.Bold, GraphicsUnit.Pixel),
+                FontType.Subtitle1 => new Font(RobotoFontFamilies["Roboto"], 16f * scaleRatio, FontStyle.Regular, GraphicsUnit.Pixel),
+                FontType.Subtitle2 => new Font(RobotoFontFamilies["Roboto_Medium"], 14f * scaleRatio, FontStyle.Bold, GraphicsUnit.Pixel),
+                FontType.SubtleEmphasis => new Font(RobotoFontFamilies["Roboto"], 12f * scaleRatio, FontStyle.Italic, GraphicsUnit.Pixel),
+                FontType.Body1 => new Font(RobotoFontFamilies["Roboto"], 14f * scaleRatio, FontStyle.Regular, GraphicsUnit.Pixel),
+                FontType.Body2 => new Font(RobotoFontFamilies["Roboto"], 12f * scaleRatio, FontStyle.Regular, GraphicsUnit.Pixel),
+                FontType.Button => new Font(RobotoFontFamilies["Roboto"], 14f * scaleRatio, FontStyle.Bold, GraphicsUnit.Pixel),
+                FontType.Caption => new Font(RobotoFontFamilies["Roboto"], 12f * scaleRatio, FontStyle.Regular, GraphicsUnit.Pixel),
+                FontType.Overline => new Font(RobotoFontFamilies["Roboto"], 10f * scaleRatio, FontStyle.Regular, GraphicsUnit.Pixel),
+                _ => new Font(RobotoFontFamilies["Roboto"], 14f * scaleRatio, FontStyle.Regular, GraphicsUnit.Pixel),
             };
         }
 
@@ -328,12 +334,30 @@ namespace ReaLTaiizor.Manager
             return logicalFonts[System.Enum.GetName(typeof(FontType), type)];
         }
 
+        public IntPtr GetLogFontByType(FontType type, float scaleRatio)
+        {
+            var hOriginalFont = logicalFonts[System.Enum.GetName(typeof(FontType), type)];
+            if (scaleRatio == 1) return hOriginalFont;
+            LogFont lf = new LogFont();
+            if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
+            {
+                return IntPtr.Zero; // Failed fetching handle
+            }
+            return createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(),lf.lfWeight), lfItalic:lf.lfItalic);
+            
+        }
+        
         // Font stuff
         private Dictionary<string, IntPtr> logicalFonts;
 
         private Dictionary<string, FontFamily> RobotoFontFamilies;
 
         private PrivateFontCollection privateFontCollection = new();
+
+        [DllImport("gdi32.dll", CharSet = CharSet.Auto)]
+        public static extern int GetObject(IntPtr hFont, int nSize, [In, Out] LogFont lf);
+
+        
 
         private void addFont(byte[] fontdata)
         {

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -335,15 +335,15 @@ namespace ReaLTaiizor.Manager
         {
             int scaleKey = (int)Math.Round(scaleRatio * 100);
             string key = "textBox" + Math.Min(16, Math.Max(12, size)).ToString() + "-scale" + scaleKey;
-            if (logicalFonts.TryGetValue(key, out var existingFont))
+            if (logicalFonts.TryGetValue(key, out IntPtr existingFont))
             {
                 return existingFont;
             }
             lock (_fontLock)
             {
-                if (logicalFonts.TryGetValue(key, out var h))
+                if (logicalFonts.TryGetValue(key, out IntPtr h))
                     return h;
-                var hOriginalFont = GetTextBoxFontBySize(size);
+                IntPtr hOriginalFont = GetTextBoxFontBySize(size);
                 if (scaleKey == 100) return hOriginalFont;
                 LogFont lf = new LogFont();
                 if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
@@ -365,17 +365,17 @@ namespace ReaLTaiizor.Manager
         {
             int scaleKey = (int)Math.Round(scaleRatio * 100);
             string key = System.Enum.GetName(typeof(FontType), type) + "-scale" + scaleKey;
-            if (logicalFonts.TryGetValue(key, out var existingFont))
+            if (logicalFonts.TryGetValue(key, out IntPtr existingFont))
             {
                 return existingFont;
             }
             lock (_fontLock)
             {
-                if (logicalFonts.TryGetValue(key, out var cachedFont))
+                if (logicalFonts.TryGetValue(key, out IntPtr cachedFont))
                 {
                     return cachedFont;
                 }
-                var hOriginalFont = logicalFonts[System.Enum.GetName(typeof(FontType), type)];
+                IntPtr hOriginalFont = logicalFonts[System.Enum.GetName(typeof(FontType), type)];
                 if (scaleRatio == 1) return hOriginalFont;
                 LogFont lf = new LogFont();
                 if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0)
@@ -387,7 +387,7 @@ namespace ReaLTaiizor.Manager
                 return createdFont;
             }
         }
-        
+
         // Font stuff
         private Dictionary<string, IntPtr> logicalFonts;
 
@@ -398,7 +398,7 @@ namespace ReaLTaiizor.Manager
         [DllImport("gdi32.dll", CharSet = CharSet.Auto)]
         public static extern int GetObject(IntPtr hFont, int nSize, [In, Out] LogFont lf);
 
-        
+
 
         private void addFont(byte[] fontdata)
         {

--- a/src/ReaLTaiizor/ReaLTaiizor.cs
+++ b/src/ReaLTaiizor/ReaLTaiizor.cs
@@ -13,7 +13,7 @@ using System.Windows.Forms;
 //     Creator: Taiizor
 //     Website: www.vegalya.com
 //     Created: 15.May.2019
-//     Changed: 26.Jan.2026
+//     Changed: 04.Feb.2026
 //     Version: 3.8.1.6
 //
 // |---------DO-NOT-REMOVE---------|

--- a/src/ReaLTaiizor/ReaLTaiizor.csproj
+++ b/src/ReaLTaiizor/ReaLTaiizor.csproj
@@ -16,7 +16,7 @@
     <PropertyGroup>
         <UseWindowsForms>true</UseWindowsForms>
         <ApplicationIcon>Resources\Taiizor.ico</ApplicationIcon>
-        <Version>3.8.1.9</Version>
+        <Version>3.8.1.6</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Title>ReaLTaiizor</Title>

--- a/src/ReaLTaiizor/ReaLTaiizor.csproj
+++ b/src/ReaLTaiizor/ReaLTaiizor.csproj
@@ -16,7 +16,7 @@
     <PropertyGroup>
         <UseWindowsForms>true</UseWindowsForms>
         <ApplicationIcon>Resources\Taiizor.ico</ApplicationIcon>
-        <Version>3.8.1.6</Version>
+        <Version>3.8.1.8</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Title>ReaLTaiizor</Title>

--- a/src/ReaLTaiizor/ReaLTaiizor.csproj
+++ b/src/ReaLTaiizor/ReaLTaiizor.csproj
@@ -16,7 +16,7 @@
     <PropertyGroup>
         <UseWindowsForms>true</UseWindowsForms>
         <ApplicationIcon>Resources\Taiizor.ico</ApplicationIcon>
-        <Version>3.8.1.8</Version>
+        <Version>3.8.1.9</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Title>ReaLTaiizor</Title>


### PR DESCRIPTION
This Pull Request is aimed to provide a complete Windows DPI scaling support to Material Controls, and offer scaling code standard to controls after.
Meanwhile, these pushes solved many problems (such as magic numbers and wrong logic) remained in old code. The code afterwards will become more readable, maintainable and usable.

### Before these pushes
<img width="3199" height="1999" alt="image" src="https://github.com/user-attachments/assets/ccc8b817-d78b-4ce8-b065-097c8ce22e8b" />

### After these pushes
<img width="2437" height="1589" alt="image" src="https://github.com/user-attachments/assets/a5bf8a16-47a3-439e-ae33-fb7fc2e04388" />
