### PR TITLE
Fixing Copilot generated false Font processing logic

### DIFF
--- a/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
+++ b/src/ReaLTaiizor/Controls/CheckBox/MaterialCheckBox.cs
@@ -199,7 +199,7 @@ namespace ReaLTaiizor.Controls
 
             using (MaterialNativeTextRenderer NativeText = new(CreateGraphics()))
             {
-                strSize = NativeText.MeasureLogString(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1));
+                strSize = NativeText.MeasureLogString(Text, SkinManager.GetLogFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor));
             }
 
             float scale = ScaleFactor;

--- a/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
@@ -62,39 +62,39 @@ namespace ReaLTaiizor.Forms
 
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.MaterialFlexibleFormBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.components = new Container();
+            this.MaterialFlexibleFormBindingSource = new BindingSource(this.components);
             this.messageContainer = new System.Windows.Forms.Panel();
-            this.materialLabel1 = new ReaLTaiizor.Controls.MaterialLabel();
-            this.pictureBoxForIcon = new System.Windows.Forms.PictureBox();
-            this.richTextBoxMessage = new ReaLTaiizor.Controls.MaterialMultiLineTextBoxEdit();
-            this.leftButton = new ReaLTaiizor.Controls.MaterialButton();
-            this.middleButton = new ReaLTaiizor.Controls.MaterialButton();
-            this.rightButton = new ReaLTaiizor.Controls.MaterialButton();
-            ((System.ComponentModel.ISupportInitialize)(this.MaterialFlexibleFormBindingSource)).BeginInit();
+            this.materialLabel1 = new MaterialLabel();
+            this.pictureBoxForIcon = new PictureBox();
+            this.richTextBoxMessage = new MaterialMultiLineTextBoxEdit();
+            this.leftButton = new MaterialButton();
+            this.middleButton = new MaterialButton();
+            this.rightButton = new MaterialButton();
+            ((ISupportInitialize)this.MaterialFlexibleFormBindingSource).BeginInit();
             this.messageContainer.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxForIcon)).BeginInit();
+            ((ISupportInitialize)this.pictureBoxForIcon).BeginInit();
             this.SuspendLayout();
             // 
             // messageContainer
             // 
-            this.messageContainer.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.messageContainer.BackColor = System.Drawing.Color.White;
+            this.messageContainer.Anchor = (AnchorStyles)(AnchorStyles.Top | AnchorStyles.Bottom
+            | AnchorStyles.Left
+            | AnchorStyles.Right);
+            this.messageContainer.BackColor = Color.White;
             this.messageContainer.Controls.Add(this.materialLabel1);
             this.messageContainer.Controls.Add(this.pictureBoxForIcon);
             this.messageContainer.Controls.Add(this.richTextBoxMessage);
-            this.messageContainer.Location = new System.Drawing.Point(1, (int)((STATU_BAR_PADDING + ACTION_BAR_PADDING + 10) * ScaleFactor));
+            this.messageContainer.Location = new Point(1, (int)((STATU_BAR_PADDING + ACTION_BAR_PADDING + 10) * ScaleFactor));
             this.messageContainer.Name = "messageContainer";
             this.messageContainer.Size = new System.Drawing.Size(445, 135);
             this.messageContainer.TabIndex = 1;
             // 
             // materialLabel1
             // 
-            this.materialLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialLabel1.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left
+            | System.Windows.Forms.AnchorStyles.Right);
             this.materialLabel1.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.MaterialFlexibleFormBindingSource, "MessageText", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.materialLabel1.Depth = 0;
             this.materialLabel1.Font = new System.Drawing.Font("Roboto", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
@@ -117,9 +117,9 @@ namespace ReaLTaiizor.Forms
             // 
             // richTextBoxMessage
             // 
-            this.richTextBoxMessage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+            this.richTextBoxMessage.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left
+            | System.Windows.Forms.AnchorStyles.Right);
             this.richTextBoxMessage.AnimateReadOnly = false;
             this.richTextBoxMessage.BackColor = System.Drawing.Color.White;
             this.richTextBoxMessage.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
@@ -127,7 +127,7 @@ namespace ReaLTaiizor.Forms
             this.richTextBoxMessage.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.richTextBoxMessage.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.MaterialFlexibleFormBindingSource, "MessageText", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.richTextBoxMessage.Depth = 0;
-            this.richTextBoxMessage.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.richTextBoxMessage.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, (byte)0);
             this.richTextBoxMessage.HideSelection = true;
             this.richTextBoxMessage.Location = new System.Drawing.Point((int)(56 * ScaleFactor), 12);
             this.richTextBoxMessage.Margin = new System.Windows.Forms.Padding(0);
@@ -242,9 +242,9 @@ namespace ReaLTaiizor.Forms
             this.Text = "<Caption>";
             this.Load += new System.EventHandler(this.MaterialFlexibleForm_Load);
             this.Shown += new System.EventHandler(this.MaterialFlexibleForm_Shown);
-            ((System.ComponentModel.ISupportInitialize)(this.MaterialFlexibleFormBindingSource)).EndInit();
+            ((ISupportInitialize)this.MaterialFlexibleFormBindingSource).EndInit();
             this.messageContainer.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxForIcon)).EndInit();
+            ((ISupportInitialize)this.pictureBoxForIcon).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -480,7 +480,7 @@ namespace ReaLTaiizor.Forms
             //Calculate margins
             int marginWidth = MaterialFlexibleForm.Width - MaterialFlexibleForm.richTextBoxMessage.Width;
             int marginHeight = MaterialFlexibleForm.Height - MaterialFlexibleForm.richTextBoxMessage.Height;
-            
+
 
             int minimumHeight = MaterialFlexibleForm.messageContainer.Top + MaterialFlexibleForm.pictureBoxForIcon.Height + (int)(2 * 8 * MaterialFlexibleForm.ScaleFactor) + (int)(54 * MaterialFlexibleForm.ScaleFactor);
             if (marginHeight < minimumHeight)
@@ -713,10 +713,8 @@ namespace ReaLTaiizor.Forms
                 }
                 return _scaleRatio.Value;
             }
-            set
-            {
-                _scaleRatio = value;
-            }
+
+            set => _scaleRatio = value;
         }
         private float? _scaleRatioSqrt; // Cache
         private float ScaleFactorSqrt
@@ -729,10 +727,8 @@ namespace ReaLTaiizor.Forms
                 }
                 return _scaleRatioSqrt.Value;
             }
-            set
-            {
-                _scaleRatioSqrt = value;
-            }
+
+            set => _scaleRatioSqrt = value;
         }
 
         public static DialogResult Show(IWin32Window owner, string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, bool UseRichTextBox = true, ButtonsPosition buttonsPosition = ButtonsPosition.Right)
@@ -747,7 +743,7 @@ namespace ReaLTaiizor.Forms
                 CaptionText = caption,
                 MessageText = text
             };
-            
+
             MaterialFlexibleForm.Width = (int)(MaterialFlexibleForm.Width * MaterialFlexibleForm.ScaleFactor);
             MaterialFlexibleForm.Height = (int)(MaterialFlexibleForm.Height * MaterialFlexibleForm.ScaleFactor);
             MaterialFlexibleForm.MaterialFlexibleFormBindingSource.DataSource = MaterialFlexibleForm;

--- a/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
@@ -27,6 +27,11 @@ namespace ReaLTaiizor.Forms
 
         public static double MAX_HEIGHT_FACTOR = 0.9;
 
+        private const int STATU_BAR_PADDING = 24;
+        private const int ACTION_BAR_PADDING = 40;
+        private const int CONTENT_VERTICAL_PADDING = 20;
+        private const int BUTTON_BAR_PADDING = 10;
+
         private MaterialMultiLineTextBoxEdit richTextBoxMessage;
         private MaterialLabel materialLabel1;
         private MaterialButton leftButton;
@@ -60,43 +65,43 @@ namespace ReaLTaiizor.Forms
             this.components = new System.ComponentModel.Container();
             this.MaterialFlexibleFormBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.messageContainer = new System.Windows.Forms.Panel();
-            this.materialLabel1 = new MaterialLabel();
+            this.materialLabel1 = new ReaLTaiizor.Controls.MaterialLabel();
             this.pictureBoxForIcon = new System.Windows.Forms.PictureBox();
-            this.richTextBoxMessage = new MaterialMultiLineTextBoxEdit();
-            this.leftButton = new MaterialButton();
-            this.middleButton = new MaterialButton();
-            this.rightButton = new MaterialButton();
-            ((System.ComponentModel.ISupportInitialize)this.MaterialFlexibleFormBindingSource).BeginInit();
+            this.richTextBoxMessage = new ReaLTaiizor.Controls.MaterialMultiLineTextBoxEdit();
+            this.leftButton = new ReaLTaiizor.Controls.MaterialButton();
+            this.middleButton = new ReaLTaiizor.Controls.MaterialButton();
+            this.rightButton = new ReaLTaiizor.Controls.MaterialButton();
+            ((System.ComponentModel.ISupportInitialize)(this.MaterialFlexibleFormBindingSource)).BeginInit();
             this.messageContainer.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)this.pictureBoxForIcon).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxForIcon)).BeginInit();
             this.SuspendLayout();
             // 
             // messageContainer
             // 
-            this.messageContainer.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Left
-            | System.Windows.Forms.AnchorStyles.Right);
+            this.messageContainer.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.messageContainer.BackColor = System.Drawing.Color.White;
             this.messageContainer.Controls.Add(this.materialLabel1);
             this.messageContainer.Controls.Add(this.pictureBoxForIcon);
             this.messageContainer.Controls.Add(this.richTextBoxMessage);
-            this.messageContainer.Location = new System.Drawing.Point(1, 65);
+            this.messageContainer.Location = new System.Drawing.Point(1, (int)((STATU_BAR_PADDING + ACTION_BAR_PADDING + 10) * ScaleFactor));
             this.messageContainer.Name = "messageContainer";
-            this.messageContainer.Size = new System.Drawing.Size(382, 89);
+            this.messageContainer.Size = new System.Drawing.Size(445, 135);
             this.messageContainer.TabIndex = 1;
             // 
             // materialLabel1
             // 
-            this.materialLabel1.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Left
-            | System.Windows.Forms.AnchorStyles.Right);
+            this.materialLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.materialLabel1.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.MaterialFlexibleFormBindingSource, "MessageText", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.materialLabel1.Depth = 0;
             this.materialLabel1.Font = new System.Drawing.Font("Roboto", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
             this.materialLabel1.Location = new System.Drawing.Point(56, 12);
-            this.materialLabel1.MouseState = MaterialMouseState.HOVER;
+            this.materialLabel1.MouseState = ReaLTaiizor.Helper.MaterialDrawHelper.MaterialMouseState.HOVER;
             this.materialLabel1.Name = "materialLabel1";
-            this.materialLabel1.Size = new System.Drawing.Size(314, 65);
+            this.materialLabel1.Size = new System.Drawing.Size(377, 111);
             this.materialLabel1.TabIndex = 9;
             this.materialLabel1.Text = "<Message>";
             this.materialLabel1.Visible = false;
@@ -104,54 +109,66 @@ namespace ReaLTaiizor.Forms
             // pictureBoxForIcon
             // 
             this.pictureBoxForIcon.BackColor = System.Drawing.Color.Transparent;
-            this.pictureBoxForIcon.Location = new System.Drawing.Point(12, 12);
+            this.pictureBoxForIcon.Location = new System.Drawing.Point((int)(12 * ScaleFactor), 12);
             this.pictureBoxForIcon.Name = "pictureBoxForIcon";
-            this.pictureBoxForIcon.Size = new System.Drawing.Size(32, 32);
+            this.pictureBoxForIcon.Size = new System.Drawing.Size((int)(32 * ScaleFactor), (int)(32 * ScaleFactor));
             this.pictureBoxForIcon.TabIndex = 8;
             this.pictureBoxForIcon.TabStop = false;
             // 
             // richTextBoxMessage
             // 
-            this.richTextBoxMessage.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Left
-            | System.Windows.Forms.AnchorStyles.Right);
-            this.richTextBoxMessage.BackColor = System.Drawing.Color.FromArgb((int)(byte)255, (int)(byte)255, (int)(byte)255);
-            //this.richTextBoxMessage.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.richTextBoxMessage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.richTextBoxMessage.AnimateReadOnly = false;
+            this.richTextBoxMessage.BackColor = System.Drawing.Color.White;
+            this.richTextBoxMessage.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
+            this.richTextBoxMessage.CharacterCasing = System.Windows.Forms.CharacterCasing.Normal;
+            this.richTextBoxMessage.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.richTextBoxMessage.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.MaterialFlexibleFormBindingSource, "MessageText", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.richTextBoxMessage.Depth = 0;
-            this.richTextBoxMessage.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, (byte)0);
-            this.richTextBoxMessage.ForeColor = System.Drawing.Color.FromArgb((int)(byte)222, (int)(byte)0, (int)(byte)0, (int)(byte)0);
-            this.richTextBoxMessage.Location = new System.Drawing.Point(56, 12);
+            this.richTextBoxMessage.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.richTextBoxMessage.HideSelection = true;
+            this.richTextBoxMessage.Location = new System.Drawing.Point((int)(56 * ScaleFactor), 12);
             this.richTextBoxMessage.Margin = new System.Windows.Forms.Padding(0);
-            this.richTextBoxMessage.MouseState = MaterialMouseState.HOVER;
+            this.richTextBoxMessage.MaxLength = 32767;
+            this.richTextBoxMessage.MouseState = ReaLTaiizor.Helper.MaterialDrawHelper.MaterialMouseState.OUT;
             this.richTextBoxMessage.Name = "richTextBoxMessage";
+            this.richTextBoxMessage.PasswordChar = '\0';
             this.richTextBoxMessage.ReadOnly = true;
             this.richTextBoxMessage.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.richTextBoxMessage.Size = new System.Drawing.Size(314, 65);
+            this.richTextBoxMessage.SelectedText = "";
+            this.richTextBoxMessage.SelectionLength = 0;
+            this.richTextBoxMessage.SelectionStart = 0;
+            this.richTextBoxMessage.ShortcutsEnabled = true;
+            this.richTextBoxMessage.Size = new System.Drawing.Size(377, 111);
             this.richTextBoxMessage.TabIndex = 0;
             this.richTextBoxMessage.TabStop = false;
             this.richTextBoxMessage.Text = "<Message>";
-            //this.richTextBoxMessage.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.richTextBoxMessage_LinkClicked);
+            this.richTextBoxMessage.TextAlign = System.Windows.Forms.HorizontalAlignment.Left;
+            this.richTextBoxMessage.UseSystemPasswordChar = false;
             // 
             // leftButton
             // 
             this.leftButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.leftButton.AutoSize = false;
             this.leftButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.leftButton.Density = MaterialButton.MaterialButtonDensity.Default;
+            this.leftButton.Density = ReaLTaiizor.Controls.MaterialButton.MaterialButtonDensity.Default;
             this.leftButton.Depth = 0;
             this.leftButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.leftButton.HighEmphasis = false;
             this.leftButton.Icon = null;
-            this.leftButton.Location = new System.Drawing.Point(32, 163);
+            this.leftButton.IconType = ReaLTaiizor.Controls.MaterialButton.MaterialIconType.Rebase;
+            this.leftButton.Location = new System.Drawing.Point(63, 209);
             this.leftButton.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
             this.leftButton.MinimumSize = new System.Drawing.Size(0, 24);
-            this.leftButton.MouseState = MaterialMouseState.HOVER;
+            this.leftButton.MouseState = ReaLTaiizor.Helper.MaterialDrawHelper.MaterialMouseState.HOVER;
             this.leftButton.Name = "leftButton";
+            this.leftButton.NoAccentTextColor = System.Drawing.Color.Empty;
             this.leftButton.Size = new System.Drawing.Size(108, 36);
             this.leftButton.TabIndex = 14;
             this.leftButton.Text = "OK";
-            this.leftButton.Type = MaterialButton.MaterialButtonType.Text;
+            this.leftButton.Type = ReaLTaiizor.Controls.MaterialButton.MaterialButtonType.Text;
             this.leftButton.UseAccentColor = false;
             this.leftButton.UseVisualStyleBackColor = true;
             this.leftButton.Visible = false;
@@ -161,20 +178,22 @@ namespace ReaLTaiizor.Forms
             this.middleButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.middleButton.AutoSize = false;
             this.middleButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.middleButton.Density = MaterialButton.MaterialButtonDensity.Default;
+            this.middleButton.Density = ReaLTaiizor.Controls.MaterialButton.MaterialButtonDensity.Default;
             this.middleButton.Depth = 0;
             this.middleButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.middleButton.HighEmphasis = true;
             this.middleButton.Icon = null;
-            this.middleButton.Location = new System.Drawing.Point(148, 163);
+            this.middleButton.IconType = ReaLTaiizor.Controls.MaterialButton.MaterialIconType.Rebase;
+            this.middleButton.Location = new System.Drawing.Point(179, 209);
             this.middleButton.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
             this.middleButton.MinimumSize = new System.Drawing.Size(0, 24);
-            this.middleButton.MouseState = MaterialMouseState.HOVER;
+            this.middleButton.MouseState = ReaLTaiizor.Helper.MaterialDrawHelper.MaterialMouseState.HOVER;
             this.middleButton.Name = "middleButton";
+            this.middleButton.NoAccentTextColor = System.Drawing.Color.Empty;
             this.middleButton.Size = new System.Drawing.Size(102, 36);
             this.middleButton.TabIndex = 15;
             this.middleButton.Text = "OK";
-            this.middleButton.Type = MaterialButton.MaterialButtonType.Text;
+            this.middleButton.Type = ReaLTaiizor.Controls.MaterialButton.MaterialButtonType.Text;
             this.middleButton.UseAccentColor = false;
             this.middleButton.UseVisualStyleBackColor = true;
             this.middleButton.Visible = false;
@@ -184,20 +203,22 @@ namespace ReaLTaiizor.Forms
             this.rightButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.rightButton.AutoSize = false;
             this.rightButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.rightButton.Density = MaterialButton.MaterialButtonDensity.Default;
+            this.rightButton.Density = ReaLTaiizor.Controls.MaterialButton.MaterialButtonDensity.Default;
             this.rightButton.Depth = 0;
             this.rightButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.rightButton.HighEmphasis = true;
             this.rightButton.Icon = null;
-            this.rightButton.Location = new System.Drawing.Point(258, 163);
+            this.rightButton.IconType = ReaLTaiizor.Controls.MaterialButton.MaterialIconType.Rebase;
+            this.rightButton.Location = new System.Drawing.Point(289, 209);
             this.rightButton.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
             this.rightButton.MinimumSize = new System.Drawing.Size(0, 24);
-            this.rightButton.MouseState = MaterialMouseState.HOVER;
+            this.rightButton.MouseState = ReaLTaiizor.Helper.MaterialDrawHelper.MaterialMouseState.HOVER;
             this.rightButton.Name = "rightButton";
+            this.rightButton.NoAccentTextColor = System.Drawing.Color.Empty;
             this.rightButton.Size = new System.Drawing.Size(106, 36);
             this.rightButton.TabIndex = 13;
             this.rightButton.Text = "OK";
-            this.rightButton.Type = MaterialButton.MaterialButtonType.Contained;
+            this.rightButton.Type = ReaLTaiizor.Controls.MaterialButton.MaterialButtonType.Contained;
             this.rightButton.UseAccentColor = false;
             this.rightButton.UseVisualStyleBackColor = true;
             this.rightButton.Visible = false;
@@ -205,7 +226,7 @@ namespace ReaLTaiizor.Forms
             // MaterialFlexibleForm
             // 
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(384, 208);
+            this.ClientSize = new System.Drawing.Size(447, 254);
             this.Controls.Add(this.leftButton);
             this.Controls.Add(this.middleButton);
             this.Controls.Add(this.rightButton);
@@ -221,11 +242,18 @@ namespace ReaLTaiizor.Forms
             this.Text = "<Caption>";
             this.Load += new System.EventHandler(this.MaterialFlexibleForm_Load);
             this.Shown += new System.EventHandler(this.MaterialFlexibleForm_Shown);
-            ((System.ComponentModel.ISupportInitialize)this.MaterialFlexibleFormBindingSource).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.MaterialFlexibleFormBindingSource)).EndInit();
             this.messageContainer.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)this.pictureBoxForIcon).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxForIcon)).EndInit();
             this.ResumeLayout(false);
 
+        }
+
+        protected override void OnDpiChanged(DpiChangedEventArgs e)
+        {
+            ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
+            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+            base.OnDpiChanged(e);
         }
 
         private System.Windows.Forms.BindingSource MaterialFlexibleFormBindingSource;
@@ -320,7 +348,12 @@ namespace ReaLTaiizor.Forms
             /// <summary>
             /// Defines the tr
             /// </summary>
-            tr
+            tr,
+
+            /// <summary>
+            /// Defines the zh
+            /// </summary>
+            zh
         };
 
         private static readonly string[] BUTTON_TEXTS_ENGLISH_EN = { "OK", "Cancel", "&Yes", "&No", "&Abort", "&Retry", "&Ignore" }; //Note: This is also the fallback language
@@ -338,6 +371,8 @@ namespace ReaLTaiizor.Forms
         private static readonly string[] BUTTON_TEXTS_POLISH_PL = { "OK", "Anuluj", "Tak", "Nie", "Opuść", "Powtórz", "Ignoruj" };
 
         private static readonly string[] BUTTON_TEXTS_TURKISH_TR = { "Tamam", "İptal", "&Evet", "&Hayır", "&Sonlandır", "&Yeniden Dene", "&Yoksay" }; //Abort: &Durdur
+
+        private static readonly string[] BUTTON_TEXTS_SIMPLIFIED_CHINESE_ZH = { "确定", "取消", "&是", "&否", "&中止", "&重试", "&忽略" };
 
         private MessageBoxDefaultButton defaultButton;
 
@@ -357,7 +392,7 @@ namespace ReaLTaiizor.Forms
 
             materialManager = MaterialSkinManager.Instance;
             materialManager.AddFormToManage(this);
-            FONT = materialManager.GetFontByType(MaterialSkinManager.FontType.Body1);
+            FONT = materialManager.GetFontByType(MaterialSkinManager.FontType.Body1, ScaleFactor);
             messageContainer.BackColor = this.BackColor;
         }
 
@@ -385,6 +420,7 @@ namespace ReaLTaiizor.Forms
                 TwoLetterISOLanguageID.ro => BUTTON_TEXTS_ROMANIAN_RO[buttonTextArrayIndex],
                 TwoLetterISOLanguageID.pl => BUTTON_TEXTS_POLISH_PL[buttonTextArrayIndex],
                 TwoLetterISOLanguageID.tr => BUTTON_TEXTS_TURKISH_TR[buttonTextArrayIndex],
+                TwoLetterISOLanguageID.zh => BUTTON_TEXTS_SIMPLIFIED_CHINESE_ZH[buttonTextArrayIndex],
                 _ => BUTTON_TEXTS_ENGLISH_EN[buttonTextArrayIndex],
             };
         }
@@ -439,13 +475,14 @@ namespace ReaLTaiizor.Forms
             const int SCROLLBAR_WIDTH_OFFSET = 15;
             int longestTextRowWidth = stringRows.Max(textForRow => TextRenderer.MeasureText(textForRow, FONT).Width);
             int captionWidth = TextRenderer.MeasureText(caption, SystemFonts.CaptionFont).Width;
-            int textWidth = Math.Max(longestTextRowWidth + SCROLLBAR_WIDTH_OFFSET, captionWidth);
+            int textWidth = Math.Max(longestTextRowWidth + (int)(SCROLLBAR_WIDTH_OFFSET * MaterialFlexibleForm.ScaleFactor), captionWidth);
 
             //Calculate margins
             int marginWidth = MaterialFlexibleForm.Width - MaterialFlexibleForm.richTextBoxMessage.Width;
             int marginHeight = MaterialFlexibleForm.Height - MaterialFlexibleForm.richTextBoxMessage.Height;
+            
 
-            int minimumHeight = MaterialFlexibleForm.messageContainer.Top + MaterialFlexibleForm.pictureBoxForIcon.Height + (2 * 8) + 54;
+            int minimumHeight = MaterialFlexibleForm.messageContainer.Top + MaterialFlexibleForm.pictureBoxForIcon.Height + (int)(2 * 8 * MaterialFlexibleForm.ScaleFactor) + (int)(54 * MaterialFlexibleForm.ScaleFactor);
             if (marginHeight < minimumHeight)
             {
                 marginHeight = minimumHeight;
@@ -454,6 +491,7 @@ namespace ReaLTaiizor.Forms
             //Set calculated dialog size (if the calculated values exceed the maximums, they were cut by windows forms automatically)
             MaterialFlexibleForm.Size = new Size(textWidth + marginWidth,
                                                    textHeight + marginHeight);
+            MaterialFlexibleForm.messageContainer.Height = MaterialFlexibleForm.Height - (int)((ACTION_BAR_PADDING + STATU_BAR_PADDING + BUTTON_BAR_PADDING) * MaterialFlexibleForm.ScaleFactor) - MaterialFlexibleForm.rightButton.Height;
         }
 
         private static void SetDialogIcon(MaterialFlexibleForm MaterialFlexibleForm, MessageBoxIcon icon)
@@ -663,6 +701,40 @@ namespace ReaLTaiizor.Forms
 
         public string MessageText { get; set; }
 
+
+        private float? _scaleRatio; // Cache
+        private float ScaleFactor
+        {
+            get
+            {
+                if (!_scaleRatio.HasValue)
+                {
+                    _scaleRatio = SkinManager.GetDeviceScaleFactor(this);
+                }
+                return _scaleRatio.Value;
+            }
+            set
+            {
+                _scaleRatio = value;
+            }
+        }
+        private float? _scaleRatioSqrt; // Cache
+        private float ScaleFactorSqrt
+        {
+            get
+            {
+                if (!_scaleRatioSqrt.HasValue)
+                {
+                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
+                }
+                return _scaleRatioSqrt.Value;
+            }
+            set
+            {
+                _scaleRatioSqrt = value;
+            }
+        }
+
         public static DialogResult Show(IWin32Window owner, string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, bool UseRichTextBox = true, ButtonsPosition buttonsPosition = ButtonsPosition.Right)
         {
             //Create a new instance of the FlexibleMessageBox form
@@ -675,6 +747,9 @@ namespace ReaLTaiizor.Forms
                 CaptionText = caption,
                 MessageText = text
             };
+            
+            MaterialFlexibleForm.Width = (int)(MaterialFlexibleForm.Width * MaterialFlexibleForm.ScaleFactor);
+            MaterialFlexibleForm.Height = (int)(MaterialFlexibleForm.Height * MaterialFlexibleForm.ScaleFactor);
             MaterialFlexibleForm.MaterialFlexibleFormBindingSource.DataSource = MaterialFlexibleForm;
 
 
@@ -717,18 +792,18 @@ namespace ReaLTaiizor.Forms
                     {
                         case 3:
                             fMF.middleButton.Left = (fMF.Width / 2) - (fMF.middleButton.Width / 2);
-                            fMF.leftButton.Left = fMF.middleButton.Left - fMF.leftButton.Width - (padding * 2);
-                            fMF.rightButton.Left = fMF.middleButton.Right + (padding * 2);
-                            visibleButtonsWidth = fMF.leftButton.Width + fMF.middleButton.Width + fMF.rightButton.Width + (padding * 6);
+                            fMF.leftButton.Left = fMF.middleButton.Left - fMF.leftButton.Width - ((int)(padding * fMF.ScaleFactor) * 2);
+                            fMF.rightButton.Left = fMF.middleButton.Right + ((int)(padding * fMF.ScaleFactor) * 2);
+                            visibleButtonsWidth = fMF.leftButton.Width + fMF.middleButton.Width + fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 6);
                             break;
                         case 2:
-                            fMF.middleButton.Left = (fMF.Width / 2) - fMF.middleButton.Width - padding;
-                            fMF.rightButton.Left = (fMF.Width / 2) + padding;
-                            visibleButtonsWidth = fMF.middleButton.Width + fMF.rightButton.Width + (padding * 4);
+                            fMF.middleButton.Left = (fMF.Width / 2) - fMF.middleButton.Width - (int)(padding * fMF.ScaleFactor);
+                            fMF.rightButton.Left = (fMF.Width / 2) + (int)(padding * fMF.ScaleFactor);
+                            visibleButtonsWidth = fMF.middleButton.Width + fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 4);
                             break;
                         case 1:
                             fMF.rightButton.Left = (fMF.Width / 2) - (fMF.rightButton.Width / 2);
-                            visibleButtonsWidth = fMF.rightButton.Width + (padding * 2);
+                            visibleButtonsWidth = fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 2);
                             break;
                         default:
                             break;
@@ -738,19 +813,19 @@ namespace ReaLTaiizor.Forms
                     switch (fMF.visibleButtonsCount)
                     {
                         case 3:
-                            fMF.leftButton.Left = padding;
-                            fMF.middleButton.Left = fMF.leftButton.Right + (padding * 2);
-                            fMF.rightButton.Left = fMF.middleButton.Right + (padding * 2);
-                            visibleButtonsWidth = fMF.leftButton.Width + fMF.middleButton.Width + fMF.rightButton.Width + (padding * 6);
+                            fMF.leftButton.Left = (int)(padding * fMF.ScaleFactor);
+                            fMF.middleButton.Left = fMF.leftButton.Right + ((int)(padding * fMF.ScaleFactor) * 2);
+                            fMF.rightButton.Left = fMF.middleButton.Right + ((int)(padding * fMF.ScaleFactor) * 2);
+                            visibleButtonsWidth = fMF.leftButton.Width + fMF.middleButton.Width + fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 6);
                             break;
                         case 2:
-                            fMF.middleButton.Left = padding;
-                            fMF.rightButton.Left = fMF.middleButton.Right + (padding * 2);
-                            visibleButtonsWidth = fMF.middleButton.Width + fMF.rightButton.Width + (padding * 4);
+                            fMF.middleButton.Left = (int)(padding * fMF.ScaleFactor);
+                            fMF.rightButton.Left = fMF.middleButton.Right + ((int)(padding * fMF.ScaleFactor) * 2);
+                            visibleButtonsWidth = fMF.middleButton.Width + fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 4);
                             break;
                         case 1:
-                            fMF.rightButton.Left = padding;
-                            visibleButtonsWidth = fMF.rightButton.Width + (padding * 2);
+                            fMF.rightButton.Left = (int)(padding * fMF.ScaleFactor);
+                            visibleButtonsWidth = fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 2);
                             break;
                         default:
                             break;
@@ -759,19 +834,19 @@ namespace ReaLTaiizor.Forms
                 case ButtonsPosition.Right:
                     // This alignment is simplest, in this alignment doesn't care how many buttons are visible.
                     // Always the buttons visibility order is right, right + middle, right + middle + left
-                    fMF.rightButton.Left = fMF.Width - fMF.rightButton.Width - padding;
-                    fMF.middleButton.Left = fMF.rightButton.Left - fMF.middleButton.Width - (padding * 2);
-                    fMF.leftButton.Left = fMF.middleButton.Left - fMF.leftButton.Width - (padding * 2);
+                    fMF.rightButton.Left = fMF.Width - fMF.rightButton.Width - (int)(padding * fMF.ScaleFactor);
+                    fMF.middleButton.Left = fMF.rightButton.Left - fMF.middleButton.Width - ((int)(padding * fMF.ScaleFactor) * 2);
+                    fMF.leftButton.Left = fMF.middleButton.Left - fMF.leftButton.Width - ((int)(padding * fMF.ScaleFactor) * 2);
                     switch (fMF.visibleButtonsCount)
                     {
                         case 3:
-                            visibleButtonsWidth = fMF.leftButton.Width + fMF.middleButton.Width + fMF.rightButton.Width + (padding * 6);
+                            visibleButtonsWidth = fMF.leftButton.Width + fMF.middleButton.Width + fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 6);
                             break;
                         case 2:
-                            visibleButtonsWidth = fMF.middleButton.Width + fMF.rightButton.Width + (padding * 4);
+                            visibleButtonsWidth = fMF.middleButton.Width + fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 4);
                             break;
                         case 1:
-                            visibleButtonsWidth = fMF.rightButton.Width + (padding * 2);
+                            visibleButtonsWidth = fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 2);
                             break;
                         default:
                             break;
@@ -781,19 +856,19 @@ namespace ReaLTaiizor.Forms
                     switch (fMF.visibleButtonsCount)
                     {
                         case 3:
-                            fMF.leftButton.Left = padding;
+                            fMF.leftButton.Left = (int)(padding * fMF.ScaleFactor);
                             fMF.middleButton.Left = (fMF.Width / 2) - (fMF.middleButton.Width / 2);
-                            fMF.rightButton.Left = fMF.Width - fMF.rightButton.Width - (padding * 2);
-                            visibleButtonsWidth = fMF.leftButton.Width + fMF.middleButton.Width + fMF.rightButton.Width + (padding * 6);
+                            fMF.rightButton.Left = fMF.Width - fMF.rightButton.Width - ((int)(padding * fMF.ScaleFactor) * 2);
+                            visibleButtonsWidth = fMF.leftButton.Width + fMF.middleButton.Width + fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 6);
                             break;
                         case 2:
-                            fMF.middleButton.Left = padding;
-                            fMF.rightButton.Left = fMF.Width - fMF.rightButton.Width - (padding * 2);
-                            visibleButtonsWidth = fMF.middleButton.Width + fMF.rightButton.Width + (padding * 4);
+                            fMF.middleButton.Left = (int)(padding * fMF.ScaleFactor);
+                            fMF.rightButton.Left = fMF.Width - fMF.rightButton.Width - ((int)(padding * fMF.ScaleFactor) * 2);
+                            visibleButtonsWidth = fMF.middleButton.Width + fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 4);
                             break;
                         case 1:
                             fMF.rightButton.Left = (fMF.Width / 2) - (fMF.middleButton.Width / 2);
-                            visibleButtonsWidth = fMF.rightButton.Width + (padding * 2);
+                            visibleButtonsWidth = fMF.rightButton.Width + ((int)(padding * fMF.ScaleFactor) * 2);
                             break;
                         default:
                             break;

--- a/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
@@ -524,8 +524,8 @@ namespace ReaLTaiizor.Forms
             {
                 case MessageBoxIcon.Information:
                     MaterialFlexibleForm.hasIcon = true;
-                    MaterialFlexibleForm.pictureBoxForIcon.Visible = true;
                     MaterialFlexibleForm.pictureBoxForIcon.Image = SystemIcons.Information.ToBitmap();
+                    MaterialFlexibleForm.pictureBoxForIcon.Visible = true;
                     break;
 
                 case MessageBoxIcon.Warning:

--- a/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
@@ -29,7 +29,6 @@ namespace ReaLTaiizor.Forms
 
         private const int STATUS_BAR_PADDING = 24;
         private const int ACTION_BAR_PADDING = 40;
-        // private const int CONTENT_VERTICAL_PADDING = 20;
         private const int BUTTON_BAR_PADDING = 10;
         private const int BUTTONS_PADDING = 10;
 
@@ -51,12 +50,6 @@ namespace ReaLTaiizor.Forms
         public ButtonsPosition ButtonsPositionEnum { get; set; } = ButtonsPosition.Right;
 
         private IContainer components = null;
-
-        protected override void OnHandleCreated(EventArgs e)
-        {
-            base.OnHandleCreated(e);
-            
-        }
 
         protected override void Dispose(bool disposing)
         {
@@ -259,7 +252,6 @@ namespace ReaLTaiizor.Forms
         protected override void OnDpiChanged(DpiChangedEventArgs e)
         {
             ScaleFactor = SkinManager.GetDeviceScaleFactor(this);
-            ScaleFactorSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
             base.OnDpiChanged(e);
         }
 
@@ -501,6 +493,20 @@ namespace ReaLTaiizor.Forms
             //Set calculated dialog size (if the calculated values exceed the maximums, they were cut by windows forms automatically)
             MaterialFlexibleForm.Size = new Size(textWidth + marginWidth,
                                                    textHeight + marginHeight + (int)(MaterialFlexibleForm.leftButton.Height * MaterialFlexibleForm.ScaleFactor * (MaterialFlexibleForm.ScaleFactor - 1)));
+            // NOTE:
+            // This uses a quadratic term: H * S * (S - 1).
+            // The method is executed before the buttons are actually scaled.
+            // At this point, leftButton.Height still represents the original size (H),
+            // while the layout pass will later apply scaling (S).
+            //
+            // A simple linear compensation (H * (S - 1)) was insufficient,
+            // because WinForms DPI layout applies additional scaling during layout.
+            // The extra * S term compensates for this pre-layout scaling stage
+            // and avoids clipping at high DPI (e.g., 200%).
+            //
+            // Verified visually at 100% and 200% scaling.
+            // If layout order changes in the future, this formula may need adjustment.
+
             MaterialFlexibleForm.messageContainer.Height = MaterialFlexibleForm.Height - (int)((ACTION_BAR_PADDING + STATUS_BAR_PADDING + BUTTON_BAR_PADDING) * MaterialFlexibleForm.ScaleFactor) - MaterialFlexibleForm.rightButton.Height - ((int)(MaterialFlexibleForm.leftButton.Height * MaterialFlexibleForm.ScaleFactor * (MaterialFlexibleForm.ScaleFactor - 1)));
             
         }
@@ -726,20 +732,6 @@ namespace ReaLTaiizor.Forms
             }
 
             set => _scaleRatio = value;
-        }
-        private float? _scaleRatioSqrt; // Cache
-        private float ScaleFactorSqrt
-        {
-            get
-            {
-                if (!_scaleRatioSqrt.HasValue)
-                {
-                    _scaleRatioSqrt = SkinManager.GetDeviceScaleFactorSqrt(this);
-                }
-                return _scaleRatioSqrt.Value;
-            }
-
-            set => _scaleRatioSqrt = value;
         }
 
         public static DialogResult Show(IWin32Window owner, string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, bool UseRichTextBox = true, ButtonsPosition buttonsPosition = ButtonsPosition.Right)

--- a/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
@@ -31,6 +31,7 @@ namespace ReaLTaiizor.Forms
         private const int ACTION_BAR_PADDING = 40;
         // private const int CONTENT_VERTICAL_PADDING = 20;
         private const int BUTTON_BAR_PADDING = 10;
+        private const int BUTTONS_PADDING = 10;
 
         private MaterialMultiLineTextBoxEdit richTextBoxMessage;
         private MaterialLabel materialLabel1;
@@ -491,7 +492,6 @@ namespace ReaLTaiizor.Forms
             int marginWidth = MaterialFlexibleForm.Width - MaterialFlexibleForm.richTextBoxMessage.Width;
             int marginHeight = MaterialFlexibleForm.Height - MaterialFlexibleForm.richTextBoxMessage.Height;
 
-
             int minimumHeight = MaterialFlexibleForm.messageContainer.Top + MaterialFlexibleForm.pictureBoxForIcon.Height + (int)(2 * 8 * MaterialFlexibleForm.ScaleFactor) + (int)(54 * MaterialFlexibleForm.ScaleFactor);
             if (marginHeight < minimumHeight)
             {
@@ -500,8 +500,9 @@ namespace ReaLTaiizor.Forms
 
             //Set calculated dialog size (if the calculated values exceed the maximums, they were cut by windows forms automatically)
             MaterialFlexibleForm.Size = new Size(textWidth + marginWidth,
-                                                   textHeight + marginHeight);
-            MaterialFlexibleForm.messageContainer.Height = MaterialFlexibleForm.Height - (int)((ACTION_BAR_PADDING + STATUS_BAR_PADDING + BUTTON_BAR_PADDING) * MaterialFlexibleForm.ScaleFactor) - MaterialFlexibleForm.rightButton.Height;
+                                                   textHeight + marginHeight + (int)(MaterialFlexibleForm.leftButton.Height * MaterialFlexibleForm.ScaleFactor * (MaterialFlexibleForm.ScaleFactor - 1)));
+            MaterialFlexibleForm.messageContainer.Height = MaterialFlexibleForm.Height - (int)((ACTION_BAR_PADDING + STATUS_BAR_PADDING + BUTTON_BAR_PADDING) * MaterialFlexibleForm.ScaleFactor) - MaterialFlexibleForm.rightButton.Height - ((int)(MaterialFlexibleForm.leftButton.Height * MaterialFlexibleForm.ScaleFactor * (MaterialFlexibleForm.ScaleFactor - 1)));
+            
         }
 
         private static void SetDialogIcon(MaterialFlexibleForm MaterialFlexibleForm, MessageBoxIcon icon)
@@ -789,7 +790,11 @@ namespace ReaLTaiizor.Forms
 
         private static void SetButtonsPosition(MaterialFlexibleForm fMF, ButtonsPosition buttonsPosition)
         {
-            const int padding = 10;
+            const int padding = BUTTONS_PADDING;
+            fMF.leftButton.Size = new((int)(fMF.leftButton.Width * fMF.ScaleFactor), (int)(fMF.leftButton.Height * fMF.ScaleFactor));
+            fMF.middleButton.Size = new((int)(fMF.middleButton.Width * fMF.ScaleFactor), (int)(fMF.middleButton.Height * fMF.ScaleFactor));
+            fMF.rightButton.Size = new((int)(fMF.rightButton.Width * fMF.ScaleFactor), (int)(fMF.rightButton.Height * fMF.ScaleFactor));
+            
             int visibleButtonsWidth = 0;
             switch (buttonsPosition)
             {

--- a/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
@@ -27,9 +27,9 @@ namespace ReaLTaiizor.Forms
 
         public static double MAX_HEIGHT_FACTOR = 0.9;
 
-        private const int STATU_BAR_PADDING = 24;
+        private const int STATUS_BAR_PADDING = 24;
         private const int ACTION_BAR_PADDING = 40;
-        private const int CONTENT_VERTICAL_PADDING = 20;
+        // private const int CONTENT_VERTICAL_PADDING = 20;
         private const int BUTTON_BAR_PADDING = 10;
 
         private MaterialMultiLineTextBoxEdit richTextBoxMessage;
@@ -50,6 +50,12 @@ namespace ReaLTaiizor.Forms
         public ButtonsPosition ButtonsPositionEnum { get; set; } = ButtonsPosition.Right;
 
         private IContainer components = null;
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            
+        }
 
         protected override void Dispose(bool disposing)
         {
@@ -85,7 +91,7 @@ namespace ReaLTaiizor.Forms
             this.messageContainer.Controls.Add(this.materialLabel1);
             this.messageContainer.Controls.Add(this.pictureBoxForIcon);
             this.messageContainer.Controls.Add(this.richTextBoxMessage);
-            this.messageContainer.Location = new Point(1, (int)((STATU_BAR_PADDING + ACTION_BAR_PADDING + 10) * ScaleFactor));
+            this.messageContainer.Location = new System.Drawing.Point(1, 65);
             this.messageContainer.Name = "messageContainer";
             this.messageContainer.Size = new System.Drawing.Size(445, 135);
             this.messageContainer.TabIndex = 1;
@@ -109,9 +115,9 @@ namespace ReaLTaiizor.Forms
             // pictureBoxForIcon
             // 
             this.pictureBoxForIcon.BackColor = System.Drawing.Color.Transparent;
-            this.pictureBoxForIcon.Location = new System.Drawing.Point((int)(12 * ScaleFactor), 12);
+            this.pictureBoxForIcon.Location = new System.Drawing.Point(12, 12);
             this.pictureBoxForIcon.Name = "pictureBoxForIcon";
-            this.pictureBoxForIcon.Size = new System.Drawing.Size((int)(32 * ScaleFactor), (int)(32 * ScaleFactor));
+            this.pictureBoxForIcon.Size = new System.Drawing.Size(32, 32);
             this.pictureBoxForIcon.TabIndex = 8;
             this.pictureBoxForIcon.TabStop = false;
             // 
@@ -129,7 +135,7 @@ namespace ReaLTaiizor.Forms
             this.richTextBoxMessage.Depth = 0;
             this.richTextBoxMessage.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, (byte)0);
             this.richTextBoxMessage.HideSelection = true;
-            this.richTextBoxMessage.Location = new System.Drawing.Point((int)(56 * ScaleFactor), 12);
+            this.richTextBoxMessage.Location = new System.Drawing.Point(56, 12);
             this.richTextBoxMessage.Margin = new System.Windows.Forms.Padding(0);
             this.richTextBoxMessage.MaxLength = 32767;
             this.richTextBoxMessage.MouseState = ReaLTaiizor.Helper.MaterialDrawHelper.MaterialMouseState.OUT;
@@ -457,6 +463,10 @@ namespace ReaLTaiizor.Forms
 
         private static void SetDialogSizes(MaterialFlexibleForm MaterialFlexibleForm, string text, string caption)
         {
+            MaterialFlexibleForm.messageContainer.Location = new Point(1, (int)((STATUS_BAR_PADDING + ACTION_BAR_PADDING + 10) * MaterialFlexibleForm.ScaleFactor));
+            MaterialFlexibleForm.pictureBoxForIcon.Size = new System.Drawing.Size((int)(32 * MaterialFlexibleForm.ScaleFactor), (int)(32 * MaterialFlexibleForm.ScaleFactor));
+            MaterialFlexibleForm.pictureBoxForIcon.Location = new System.Drawing.Point((int)(12 * MaterialFlexibleForm.ScaleFactor), 12);
+            MaterialFlexibleForm.richTextBoxMessage.Location = new System.Drawing.Point((int)(56 * MaterialFlexibleForm.ScaleFactor), 12);
             //First set the bounds for the maximum dialog size
             MaterialFlexibleForm.MaximumSize = new Size(Convert.ToInt32(SystemInformation.WorkingArea.Width * MaterialFlexibleForm.GetCorrectedWorkingAreaFactor(MAX_WIDTH_FACTOR)),
                                                           Convert.ToInt32(SystemInformation.WorkingArea.Height * MaterialFlexibleForm.GetCorrectedWorkingAreaFactor(MAX_HEIGHT_FACTOR)));
@@ -491,7 +501,7 @@ namespace ReaLTaiizor.Forms
             //Set calculated dialog size (if the calculated values exceed the maximums, they were cut by windows forms automatically)
             MaterialFlexibleForm.Size = new Size(textWidth + marginWidth,
                                                    textHeight + marginHeight);
-            MaterialFlexibleForm.messageContainer.Height = MaterialFlexibleForm.Height - (int)((ACTION_BAR_PADDING + STATU_BAR_PADDING + BUTTON_BAR_PADDING) * MaterialFlexibleForm.ScaleFactor) - MaterialFlexibleForm.rightButton.Height;
+            MaterialFlexibleForm.messageContainer.Height = MaterialFlexibleForm.Height - (int)((ACTION_BAR_PADDING + STATUS_BAR_PADDING + BUTTON_BAR_PADDING) * MaterialFlexibleForm.ScaleFactor) - MaterialFlexibleForm.rightButton.Height;
         }
 
         private static void SetDialogIcon(MaterialFlexibleForm MaterialFlexibleForm, MessageBoxIcon icon)

--- a/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
@@ -459,7 +459,12 @@ namespace ReaLTaiizor.Forms
             MaterialFlexibleForm.messageContainer.Location = new Point(1, (int)((STATUS_BAR_PADDING + ACTION_BAR_PADDING + 10) * MaterialFlexibleForm.ScaleFactor));
             MaterialFlexibleForm.pictureBoxForIcon.Size = new System.Drawing.Size((int)(32 * MaterialFlexibleForm.ScaleFactor), (int)(32 * MaterialFlexibleForm.ScaleFactor));
             MaterialFlexibleForm.pictureBoxForIcon.Location = new System.Drawing.Point((int)(12 * MaterialFlexibleForm.ScaleFactor), 12);
-            MaterialFlexibleForm.richTextBoxMessage.Location = new System.Drawing.Point((int)(56 * MaterialFlexibleForm.ScaleFactor), 12);
+            bool hasIcon = MaterialFlexibleForm.pictureBoxForIcon.Visible;
+            int contentLeft = hasIcon
+                ? (int)(56 * MaterialFlexibleForm.ScaleFactor)
+                : (int)(24 * MaterialFlexibleForm.ScaleFactor);
+            MaterialFlexibleForm.richTextBoxMessage.Location = new System.Drawing.Point(contentLeft, 12);
+            MaterialFlexibleForm.materialLabel1.Location = new System.Drawing.Point(contentLeft, 12);
             //First set the bounds for the maximum dialog size
             MaterialFlexibleForm.MaximumSize = new Size(Convert.ToInt32(SystemInformation.WorkingArea.Width * MaterialFlexibleForm.GetCorrectedWorkingAreaFactor(MAX_WIDTH_FACTOR)),
                                                           Convert.ToInt32(SystemInformation.WorkingArea.Height * MaterialFlexibleForm.GetCorrectedWorkingAreaFactor(MAX_HEIGHT_FACTOR)));

--- a/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
+++ b/src/ReaLTaiizor/Forms/Form/MaterialFlexibleForm.cs
@@ -23,6 +23,8 @@ namespace ReaLTaiizor.Forms
 
         public static Font FONT;
 
+        bool hasIcon;
+
         public static double MAX_WIDTH_FACTOR = 0.7;
 
         public static double MAX_HEIGHT_FACTOR = 0.9;
@@ -459,8 +461,8 @@ namespace ReaLTaiizor.Forms
             MaterialFlexibleForm.messageContainer.Location = new Point(1, (int)((STATUS_BAR_PADDING + ACTION_BAR_PADDING + 10) * MaterialFlexibleForm.ScaleFactor));
             MaterialFlexibleForm.pictureBoxForIcon.Size = new System.Drawing.Size((int)(32 * MaterialFlexibleForm.ScaleFactor), (int)(32 * MaterialFlexibleForm.ScaleFactor));
             MaterialFlexibleForm.pictureBoxForIcon.Location = new System.Drawing.Point((int)(12 * MaterialFlexibleForm.ScaleFactor), 12);
-            bool hasIcon = MaterialFlexibleForm.pictureBoxForIcon.Visible;
-            int contentLeft = hasIcon
+            // Form did not show and MaterialFlexibleForm.pictureBoxForIcon.Visible will return false forever.
+            int contentLeft = MaterialFlexibleForm.hasIcon
                 ? (int)(56 * MaterialFlexibleForm.ScaleFactor)
                 : (int)(24 * MaterialFlexibleForm.ScaleFactor);
             MaterialFlexibleForm.richTextBoxMessage.Location = new System.Drawing.Point(contentLeft, 12);
@@ -521,22 +523,30 @@ namespace ReaLTaiizor.Forms
             switch (icon)
             {
                 case MessageBoxIcon.Information:
+                    MaterialFlexibleForm.hasIcon = true;
+                    MaterialFlexibleForm.pictureBoxForIcon.Visible = true;
                     MaterialFlexibleForm.pictureBoxForIcon.Image = SystemIcons.Information.ToBitmap();
                     break;
 
                 case MessageBoxIcon.Warning:
+                    MaterialFlexibleForm.hasIcon = true;
                     MaterialFlexibleForm.pictureBoxForIcon.Image = SystemIcons.Warning.ToBitmap();
+                    MaterialFlexibleForm.pictureBoxForIcon.Visible = true;
                     break;
 
                 case MessageBoxIcon.Error:
+                    MaterialFlexibleForm.hasIcon = true;
                     MaterialFlexibleForm.pictureBoxForIcon.Image = SystemIcons.Error.ToBitmap();
+                    MaterialFlexibleForm.pictureBoxForIcon.Visible = true;
                     break;
 
                 case MessageBoxIcon.Question:
+                    MaterialFlexibleForm.hasIcon = true;
                     MaterialFlexibleForm.pictureBoxForIcon.Image = SystemIcons.Question.ToBitmap();
+                    MaterialFlexibleForm.pictureBoxForIcon.Visible = true;
                     break;
-
                 default:
+                    MaterialFlexibleForm.hasIcon = false;
                     //When no icon is used: Correct placement and width of rich text box.
                     MaterialFlexibleForm.pictureBoxForIcon.Visible = false;
                     MaterialFlexibleForm.richTextBoxMessage.Left -= MaterialFlexibleForm.pictureBoxForIcon.Width;

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -136,16 +136,7 @@ namespace ReaLTaiizor.Manager
             // future, they should be added to this initialization explicitly.
 
             // create and save font handles for GDI
-            logicalFonts = new Dictionary<string, IntPtr>();
-            //{
-            //    { "H1", createLogicalFont("Roboto Light", 96, MaterialNativeTextRenderer.logFontWeight.FW_LIGHT) },
-            //    { "H2", createLogicalFont("Roboto Light", 60, MaterialNativeTextRenderer.logFontWeight.FW_LIGHT) },
-            //    { "H3", createLogicalFont("Roboto", 48, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-            //    { "H4", createLogicalFont("Roboto", 34, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-            //    { "H5", createLogicalFont("Roboto", 24, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-            //    { "H6", createLogicalFont("Roboto Medium", 20, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
-            //    { "Subtitle1", createLogicalFont("Roboto", 16, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-            //    { "Subtitle2", createLogicalFont("Roboto Medium", 14, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
+            logicalFonts = [];
         }
 
         // Destructor

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -33,12 +33,19 @@ namespace ReaLTaiizor.Manager
             public IntPtr Create(float scaleRatio)
             {
                 int scaledSize = (int)Math.Round(PixelSize * scaleRatio);
-                return createLogicalFont(
+                IntPtr fontHandle = createLogicalFont(
                     FaceName,
                     scaledSize,
                     Weight,
                     Italic
                 );
+
+                if (fontHandle == IntPtr.Zero)
+                {
+                    throw new InvalidOperationException("Failed to create logical font using CreateFontIndirect.");
+                }
+
+                return fontHandle;
             }
         }
 

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -451,38 +451,6 @@ namespace ReaLTaiizor.Manager
                 logicalFonts[cacheKey] = hFont;
                 return hFont;
             }
-
-            //int scaleKey = (int)Math.Round(scaleRatio * 100);
-            //string key = System.Enum.GetName(typeof(FontType), type) + "-scale" + scaleKey;
-            //if (logicalFonts.TryGetValue(key, out IntPtr existingFont))
-            //{
-            //    return existingFont;
-            //}
-            //lock (_fontLock)
-            //{
-            //    if (logicalFonts.TryGetValue(key, out IntPtr cachedFont))
-            //    {
-            //        return cachedFont;
-            //    }
-            //    IntPtr hOriginalFont = logicalFonts[System.Enum.GetName(typeof(FontType), type)];
-            //    if (Math.Abs(scaleRatio - 1f) < 0.0001f)
-            //    {
-            //        return hOriginalFont;
-            //    }
-
-            //    LogFont lf = new();
-            //    if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0) return IntPtr.Zero; // Failed fetching handle
-            //    IntPtr createdFont = createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(), lf.lfWeight), lfItalic: lf.lfItalic);
-            //    logicalFonts.Add(key, createdFont);
-            //    return createdFont;
-
-            //    //using Font originalFont = Font.FromHfont(hOriginalFont);
-            //    //float newSize = originalFont.Size * (float)scaleRatio;
-            //    //using Font scaledFont = new(originalFont.FontFamily, newSize, originalFont.Style, originalFont.Unit);
-            //    //IntPtr createdFont = scaledFont.ToHfont();
-            //    //logicalFonts.Add(key, createdFont);
-            //    //return createdFont;
-            //}
         }
 
         // Font stuff

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -61,7 +61,7 @@ namespace ReaLTaiizor.Manager
         /// <summary>
         /// Create LFont Descriptor Object for TextBox Rendering
         /// </summary>
-        /// <param name="size">Should in [12, 16]</param>
+        /// <param name="size">Should be in [12, 16]</param>
         /// <returns></returns>
         private FontDescriptor CreateTextBoxDescriptor(int size)
         {
@@ -476,15 +476,7 @@ namespace ReaLTaiizor.Manager
             foreach (var type in fontDescriptors.Keys)
             {
                 string cacheKey = $"{type}-scale{scaleKey}";
-                if (logicalFonts.TryGetValue(cacheKey, out IntPtr cached))
-                {
-                    continue;
-                }
-
-                if (!fontDescriptors.TryGetValue(type, out FontDescriptor descriptor))
-                {
-                    throw new ArgumentException($"No font descriptor is registered for font type '{type}'.", nameof(type));
-                }
+                fontDescriptors.TryGetValue(type, out FontDescriptor descriptor);
                 IntPtr hFont = descriptor.Create(scaleRatio);
                 logicalFonts[cacheKey] = hFont;
             }
@@ -495,7 +487,6 @@ namespace ReaLTaiizor.Manager
                 {
                     continue;
                 }
-
                 FontDescriptor descriptor = CreateTextBoxDescriptor(i);
                 IntPtr hFont = descriptor.Create(scaleRatio);
                 logicalFonts[cacheKey] = hFont;

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -13,6 +13,7 @@ using System.Drawing.Text;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using static ReaLTaiizor.Util.MaterialNativeTextRenderer;
 
 #endregion
 
@@ -392,12 +393,18 @@ namespace ReaLTaiizor.Manager
                     return hOriginalFont;
                 }
 
-                using Font originalFont = Font.FromHfont(hOriginalFont);
-                float newSize = originalFont.Size * (float)scaleRatio;
-                using Font scaledFont = new(originalFont.FontFamily, newSize, originalFont.Style, originalFont.Unit);
-                IntPtr createdFont = scaledFont.ToHfont();
+                LogFont lf = new();
+                if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0) return IntPtr.Zero; // Failed fetching handle
+                IntPtr createdFont = createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(), lf.lfWeight), lfItalic: lf.lfItalic);
                 logicalFonts.Add(key, createdFont);
                 return createdFont;
+
+                //using Font originalFont = Font.FromHfont(hOriginalFont);
+                //float newSize = originalFont.Size * (float)scaleRatio;
+                //using Font scaledFont = new(originalFont.FontFamily, newSize, originalFont.Style, originalFont.Unit);
+                //IntPtr createdFont = scaledFont.ToHfont();
+                //logicalFonts.Add(key, createdFont);
+                //return createdFont;
             }
         }
 
@@ -545,6 +552,10 @@ namespace ReaLTaiizor.Manager
                 }
             }
         }
+
+        [DllImport("gdi32.dll", CharSet = CharSet.Auto)]
+        public static extern int GetObject(IntPtr hFont, int nSize, [In, Out] LogFont lf);
+
     }
 
     #endregion

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -13,6 +13,7 @@ using System.Drawing.Text;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using static ReaLTaiizor.Native.WinApi;
 using static ReaLTaiizor.Util.MaterialNativeTextRenderer;
 
 #endregion
@@ -69,7 +70,7 @@ namespace ReaLTaiizor.Manager
             if (size < 12) size = 12;
             return new FontDescriptor
             (
-                size >= 13 ? "Roboto Medium" : "Roboto",
+                size <= 13 ? "Roboto Medium" : "Roboto",
                 size,
                 size >= 13
                     ? logFontWeight.FW_MEDIUM
@@ -424,6 +425,7 @@ namespace ReaLTaiizor.Manager
 
             lock (_fontLock)
             {
+                PreloadSpecifiedScaleLFonts(scaleRatio);
                 if (logicalFonts.TryGetValue(cacheKey, out cached))
                 {
                     return cached;
@@ -453,6 +455,7 @@ namespace ReaLTaiizor.Manager
 
             lock (_fontLock)
             {
+                PreloadSpecifiedScaleLFonts(scaleRatio);
                 if (logicalFonts.TryGetValue(cacheKey, out cached))
                 {
                     return cached;
@@ -465,6 +468,42 @@ namespace ReaLTaiizor.Manager
                 IntPtr hFont = descriptor.Create(scaleRatio);
                 logicalFonts[cacheKey] = hFont;
                 return hFont;
+            }
+        }
+
+        private void PreloadSpecifiedScaleLFonts(float scaleRatio)
+        {
+            int scaleKey = (int)Math.Round(scaleRatio * 100);
+            foreach (var type in fontDescriptors.Keys)
+            {
+                string cacheKey = $"{type}-scale{scaleKey}";
+                if (logicalFonts.TryGetValue(cacheKey, out IntPtr cached))
+                {
+                    continue;
+                }
+
+                if (!fontDescriptors.TryGetValue(type, out FontDescriptor descriptor))
+                {
+                    throw new ArgumentException($"No font descriptor is registered for font type '{type}'.", nameof(type));
+                }
+                IntPtr hFont = descriptor.Create(scaleRatio);
+                logicalFonts[cacheKey] = hFont;
+            }
+            for (int i = 12; i < 17; i++)
+            {
+                FontDescriptor fd = CreateTextBoxDescriptor(i);
+                string cacheKey = $"TextBox-{i}-scale{scaleKey}";
+                if (logicalFonts.TryGetValue(cacheKey, out IntPtr cached))
+                {
+                    continue;
+                }
+
+                lock (_fontLock)
+                {
+                    FontDescriptor descriptor = CreateTextBoxDescriptor(i);
+                    IntPtr hFont = descriptor.Create(scaleRatio);
+                    logicalFonts[cacheKey] = hFont;
+                }
             }
         }
 

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -28,7 +28,7 @@ namespace ReaLTaiizor.Manager
             public string FaceName;
             public int PixelSize; // Unscaled
             public logFontWeight Weight;
-            public byte Italic;
+            public byte Italic = 0;
 
             public IntPtr Create(float scaleRatio)
             {

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -419,40 +419,6 @@ namespace ReaLTaiizor.Manager
                 logicalFonts[cacheKey] = hFont;
                 return hFont;
             }
-
-            //int scaleKey = (int)Math.Round(scaleRatio * 100);
-            //string key = "textBox" + Math.Min(16, Math.Max(12, size)).ToString() + "-scale" + scaleKey;
-            //if (logicalFonts.TryGetValue(key, out IntPtr existingFont))
-            //{
-            //    return existingFont;
-            //}
-            //lock (_fontLock)
-            //{
-            //    if (logicalFonts.TryGetValue(key, out IntPtr h))
-            //    {
-            //        return h;
-            //    }
-
-            //    IntPtr hOriginalFont = GetTextBoxFontBySize(size);
-            //    if (scaleKey == 100)
-            //    {
-            //        return hOriginalFont;
-            //    }
-
-            //    try
-            //    {
-            //        using Font originalFont = Font.FromHfont(hOriginalFont);
-            //        float scaledSize = originalFont.Size * (float)scaleRatio;
-            //        using Font scaledFont = new(originalFont.FontFamily, scaledSize, originalFont.Style, originalFont.Unit);
-            //        IntPtr createdFont = scaledFont.ToHfont();
-            //        logicalFonts.Add(key, createdFont);
-            //        return createdFont;
-            //    }
-            //    catch
-            //    {
-            //        return IntPtr.Zero; // Failed fetching handle or creating scaled font
-            //    }
-            //}
         }
 
         public IntPtr GetLogFontByType(FontType type)

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -13,7 +13,6 @@ using System.Drawing.Text;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
-using static ReaLTaiizor.Native.WinApi;
 using static ReaLTaiizor.Util.MaterialNativeTextRenderer;
 
 #endregion

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -146,19 +146,6 @@ namespace ReaLTaiizor.Manager
             //    { "H6", createLogicalFont("Roboto Medium", 20, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
             //    { "Subtitle1", createLogicalFont("Roboto", 16, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
             //    { "Subtitle2", createLogicalFont("Roboto Medium", 14, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
-            //    { "SubtleEmphasis", createLogicalFont("Roboto", 12, MaterialNativeTextRenderer.logFontWeight.FW_NORMAL, 1) },
-            //    { "Body1", createLogicalFont("Roboto", 16, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-            //    { "Body2", createLogicalFont("Roboto", 14, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-            //    { "Button", createLogicalFont("Roboto Medium", 14, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
-            //    { "Caption", createLogicalFont("Roboto", 12, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-            //    { "Overline", createLogicalFont("Roboto", 10, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-            //    // Logical fonts for textbox animation
-            //    { "textBox16", createLogicalFont("Roboto", 16, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-            //    { "textBox15", createLogicalFont("Roboto", 15, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-            //    { "textBox14", createLogicalFont("Roboto", 14, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-            //    { "textBox13", createLogicalFont("Roboto Medium", 13, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
-            //    { "textBox12", createLogicalFont("Roboto Medium", 12, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) }
-            //};
         }
 
         // Destructor

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -59,7 +59,7 @@ namespace ReaLTaiizor.Manager
         }
 
         /// <summary>
-        /// 
+        /// Create LFont Descriptor Object for TextBox Rendering
         /// </summary>
         /// <param name="size">Should in [12, 16]</param>
         /// <returns></returns>
@@ -71,7 +71,7 @@ namespace ReaLTaiizor.Manager
             (
                 size <= 13 ? "Roboto Medium" : "Roboto",
                 size,
-                size >= 13
+                size <= 13
                     ? logFontWeight.FW_MEDIUM
                     : logFontWeight.FW_REGULAR,
                 0
@@ -490,19 +490,15 @@ namespace ReaLTaiizor.Manager
             }
             for (int i = 12; i < 17; i++)
             {
-                FontDescriptor fd = CreateTextBoxDescriptor(i);
                 string cacheKey = $"TextBox-{i}-scale{scaleKey}";
                 if (logicalFonts.TryGetValue(cacheKey, out IntPtr cached))
                 {
                     continue;
                 }
 
-                lock (_fontLock)
-                {
-                    FontDescriptor descriptor = CreateTextBoxDescriptor(i);
-                    IntPtr hFont = descriptor.Create(scaleRatio);
-                    logicalFonts[cacheKey] = hFont;
-                }
+                FontDescriptor descriptor = CreateTextBoxDescriptor(i);
+                IntPtr hFont = descriptor.Create(scaleRatio);
+                logicalFonts[cacheKey] = hFont;
             }
         }
 

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -424,8 +424,6 @@ namespace ReaLTaiizor.Manager
         public IntPtr GetLogFontByType(FontType type)
         {
             return GetLogFontByType(type, 1f);
-        
-            //return logicalFonts[System.Enum.GetName(typeof(FontType), type)];
         }
 
         public IntPtr GetLogFontByType(FontType type, float scaleRatio)

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -112,8 +112,8 @@ namespace ReaLTaiizor.Manager
                 { FontType.Subtitle2, new FontDescriptor { FaceName = "Roboto Medium", PixelSize = 14, Weight = logFontWeight.FW_MEDIUM } },
                 { FontType.SubtleEmphasis, new FontDescriptor { FaceName = "Roboto", PixelSize = 12, Weight = logFontWeight.FW_NORMAL, Italic = 1 } },
 
-                { FontType.Body1, new FontDescriptor { FaceName = "Roboto", PixelSize = 16, Weight = logFontWeight.FW_REGULAR } },
-                { FontType.Body2, new FontDescriptor { FaceName = "Roboto", PixelSize = 14, Weight = logFontWeight.FW_REGULAR } },
+                { FontType.Body1, new FontDescriptor { FaceName = "Roboto", PixelSize = 14, Weight = logFontWeight.FW_REGULAR } },
+                { FontType.Body2, new FontDescriptor { FaceName = "Roboto", PixelSize = 12, Weight = logFontWeight.FW_REGULAR } },
 
                 { FontType.Button, new FontDescriptor { FaceName = "Roboto Medium", PixelSize = 14, Weight = logFontWeight.FW_MEDIUM } },
                 { FontType.Caption, new FontDescriptor { FaceName = "Roboto", PixelSize = 12, Weight = logFontWeight.FW_REGULAR } },

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -25,10 +25,19 @@ namespace ReaLTaiizor.Manager
     {
         private sealed class FontDescriptor
         {
-            public string FaceName;
-            public int PixelSize; // Unscaled
-            public logFontWeight Weight;
-            public byte Italic = 0;
+            public string FaceName { get; }
+            public int PixelSize { get; } // Unscaled
+            public logFontWeight Weight { get; }
+            public byte Italic { get; } = 0;
+
+            public FontDescriptor(string faceName, int pixelSize,
+                          logFontWeight weight, byte italic = 0)
+            {
+                FaceName = faceName;
+                PixelSize = pixelSize;
+                Weight = weight;
+                Italic = italic;
+            }
 
             public IntPtr Create(float scaleRatio)
             {
@@ -49,17 +58,24 @@ namespace ReaLTaiizor.Manager
             }
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="size">Should in [12, 16]</param>
+        /// <returns></returns>
         private FontDescriptor CreateTextBoxDescriptor(int size)
         {
+            if (size > 16) size = 16;
+            if (size < 12) size = 12;
             return new FontDescriptor
-            {
-                FaceName = size >= 13 ? "Roboto Medium" : "Roboto",
-                PixelSize = size,
-                Weight = size >= 13
+            (
+                size >= 13 ? "Roboto Medium" : "Roboto",
+                size,
+                size >= 13
                     ? logFontWeight.FW_MEDIUM
                     : logFontWeight.FW_REGULAR,
-                Italic = 0
-            };
+                0
+            );
         }
 
 
@@ -108,23 +124,23 @@ namespace ReaLTaiizor.Manager
 
             fontDescriptors = new()
             {
-                { FontType.H1, new FontDescriptor { FaceName = "Roboto Light", PixelSize = 96, Weight = logFontWeight.FW_LIGHT } },
-                { FontType.H2, new FontDescriptor { FaceName = "Roboto Light", PixelSize = 60, Weight = logFontWeight.FW_LIGHT } },
-                { FontType.H3, new FontDescriptor { FaceName = "Roboto", PixelSize = 48, Weight = logFontWeight.FW_REGULAR } },
-                { FontType.H4, new FontDescriptor { FaceName = "Roboto", PixelSize = 34, Weight = logFontWeight.FW_REGULAR } },
-                { FontType.H5, new FontDescriptor { FaceName = "Roboto", PixelSize = 24, Weight = logFontWeight.FW_REGULAR } },
-                { FontType.H6, new FontDescriptor { FaceName = "Roboto Medium", PixelSize = 20, Weight = logFontWeight.FW_MEDIUM } },
+                { FontType.H1, new FontDescriptor ("Roboto Light", 96, logFontWeight.FW_LIGHT) },
+                { FontType.H2, new FontDescriptor ("Roboto Light", 60, logFontWeight.FW_LIGHT) },
+                { FontType.H3, new FontDescriptor ("Roboto", 48, logFontWeight.FW_REGULAR) },
+                { FontType.H4, new FontDescriptor ("Roboto", 34, logFontWeight.FW_REGULAR) },
+                { FontType.H5, new FontDescriptor ("Roboto", 24, logFontWeight.FW_REGULAR) },
+                { FontType.H6, new FontDescriptor ("Roboto Medium", 20, logFontWeight.FW_MEDIUM) },
 
-                { FontType.Subtitle1, new FontDescriptor { FaceName = "Roboto", PixelSize = 16, Weight = logFontWeight.FW_REGULAR } },
-                { FontType.Subtitle2, new FontDescriptor { FaceName = "Roboto Medium", PixelSize = 14, Weight = logFontWeight.FW_MEDIUM } },
-                { FontType.SubtleEmphasis, new FontDescriptor { FaceName = "Roboto", PixelSize = 12, Weight = logFontWeight.FW_NORMAL, Italic = 1 } },
+                { FontType.Subtitle1, new FontDescriptor ("Roboto", 16, logFontWeight.FW_REGULAR) },
+                { FontType.Subtitle2, new FontDescriptor ("Roboto Medium", 14, logFontWeight.FW_MEDIUM) },
+                { FontType.SubtleEmphasis, new FontDescriptor ("Roboto", 12, logFontWeight.FW_NORMAL, 1) },
 
-                { FontType.Body1, new FontDescriptor { FaceName = "Roboto", PixelSize = 14, Weight = logFontWeight.FW_REGULAR } },
-                { FontType.Body2, new FontDescriptor { FaceName = "Roboto", PixelSize = 12, Weight = logFontWeight.FW_REGULAR } },
+                { FontType.Body1, new FontDescriptor ("Roboto", 16, logFontWeight.FW_REGULAR) },
+                { FontType.Body2, new FontDescriptor ("Roboto", 14, logFontWeight.FW_REGULAR) },
 
-                { FontType.Button, new FontDescriptor { FaceName = "Roboto Medium", PixelSize = 14, Weight = logFontWeight.FW_MEDIUM } },
-                { FontType.Caption, new FontDescriptor { FaceName = "Roboto", PixelSize = 12, Weight = logFontWeight.FW_REGULAR } },
-                { FontType.Overline, new FontDescriptor { FaceName = "Roboto", PixelSize = 10, Weight = logFontWeight.FW_REGULAR } },
+                { FontType.Button, new FontDescriptor ("Roboto Medium", 14, logFontWeight.FW_MEDIUM) },
+                { FontType.Caption, new FontDescriptor ("Roboto", 12, logFontWeight.FW_REGULAR) },
+                { FontType.Overline, new FontDescriptor ("Roboto", 10, logFontWeight.FW_REGULAR) },
             };
 
             // NOTE:
@@ -138,6 +154,21 @@ namespace ReaLTaiizor.Manager
 
             // create and save font handles for GDI
             logicalFonts = [];
+            foreach (var item in fontDescriptors.Keys)
+            {
+                GetLogFontByType(item);
+                // Preload logical fonts for the default scale factor (1.0).
+                // This restores the original eager-initialization behavior for
+                // standard DPI environments (100%).
+                //
+                // In PerMonitorV2 DPI scenarios, the actual ScaleFactor may not be
+                // known at construction time. In those cases, fonts for other scale
+                // ratios will be created lazily on first request.
+                //
+                // This avoids breaking the previous initialization contract
+                // while still supporting dynamic DPI changes.
+
+            }
         }
 
         // Destructor
@@ -379,8 +410,6 @@ namespace ReaLTaiizor.Manager
         public IntPtr GetTextBoxFontBySize(int size)
         {
             return GetTextBoxFontBySize(size, 1f);
-            //string name = "textBox" + Math.Min(16, Math.Max(12, size)).ToString();
-            //return logicalFonts[name];
         }
 
         public IntPtr GetTextBoxFontBySize(int size, float scaleRatio)

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -479,7 +479,10 @@ namespace ReaLTaiizor.Manager
                     return cached;
                 }
 
-                FontDescriptor descriptor = fontDescriptors[type];
+                if (!fontDescriptors.TryGetValue(type, out FontDescriptor descriptor))
+                {
+                    throw new ArgumentException($"No font descriptor is registered for font type '{type}'.", nameof(type));
+                }
                 IntPtr hFont = descriptor.Create(scaleRatio);
                 logicalFonts[cacheKey] = hFont;
                 return hFont;

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -476,7 +476,11 @@ namespace ReaLTaiizor.Manager
             foreach (var type in fontDescriptors.Keys)
             {
                 string cacheKey = $"{type}-scale{scaleKey}";
-                fontDescriptors.TryGetValue(type, out FontDescriptor descriptor);
+                if (logicalFonts.TryGetValue(cacheKey, out IntPtr cached))
+                {
+                    continue;
+                }
+                var descriptor = fontDescriptors[type];
                 IntPtr hFont = descriptor.Create(scaleRatio);
                 logicalFonts[cacheKey] = hFont;
             }

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -130,10 +130,11 @@ namespace ReaLTaiizor.Manager
             // NOTE:
             // fontDescriptors is intentionally limited to a predefined set of FontType values
             // (H1–H6, Subtitle1/2, SubtleEmphasis, Body1/2, Button, Caption, Overline).
-            // Textbox and other dynamic font sizes are created on-the-fly and are not cached
-            // in this dictionary, to avoid an unbounded font cache and to preserve the current
-            // behavior of the public API. If additional FontType values are introduced in the
-            // future, they should be added to this initialization explicitly.
+            // Textbox and other dynamic font sizes are created on-the-fly and are not stored
+            // in this dictionary. They may be cached separately (for example, in logicalFonts)
+            // to avoid growing this dictionary without bound and to preserve the current behavior
+            // of the public API. If additional FontType values are introduced in the future, they
+            // should be added to this initialization explicitly.
 
             // create and save font handles for GDI
             logicalFonts = [];

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -120,6 +120,13 @@ namespace ReaLTaiizor.Manager
                 { FontType.Overline, new FontDescriptor { FaceName = "Roboto", PixelSize = 10, Weight = logFontWeight.FW_REGULAR } },
             };
 
+            // NOTE:
+            // fontDescriptors is intentionally limited to a predefined set of FontType values
+            // (H1–H6, Subtitle1/2, SubtleEmphasis, Body1/2, Button, Caption, Overline).
+            // Textbox and other dynamic font sizes are created on-the-fly and are not cached
+            // in this dictionary, to avoid an unbounded font cache and to preserve the current
+            // behavior of the public API. If additional FontType values are introduced in the
+            // future, they should be added to this initialization explicitly.
 
             // create and save font handles for GDI
             logicalFonts = new Dictionary<string, IntPtr>();

--- a/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
+++ b/src/ReaLTaiizor/Manager/MaterialSkinManager.cs
@@ -23,6 +23,42 @@ namespace ReaLTaiizor.Manager
 
     public class MaterialSkinManager
     {
+        private sealed class FontDescriptor
+        {
+            public string FaceName;
+            public int PixelSize; // Unscaled
+            public logFontWeight Weight;
+            public byte Italic;
+
+            public IntPtr Create(float scaleRatio)
+            {
+                int scaledSize = (int)Math.Round(PixelSize * scaleRatio);
+                return createLogicalFont(
+                    FaceName,
+                    scaledSize,
+                    Weight,
+                    Italic
+                );
+            }
+        }
+
+        private FontDescriptor CreateTextBoxDescriptor(int size)
+        {
+            return new FontDescriptor
+            {
+                FaceName = size >= 13 ? "Roboto Medium" : "Roboto",
+                PixelSize = size,
+                Weight = size >= 13
+                    ? logFontWeight.FW_MEDIUM
+                    : logFontWeight.FW_REGULAR,
+                Italic = 0
+            };
+        }
+
+
+        private readonly Dictionary<FontType, FontDescriptor> fontDescriptors;
+
+
         private readonly List<MaterialForm> _formsToManage = [];
 
         public delegate void SkinManagerEventHandler(object sender);
@@ -63,30 +99,52 @@ namespace ReaLTaiizor.Manager
                 RobotoFontFamilies.Add(ff.Name.Replace(' ', '_'), ff);
             }
 
-            // create and save font handles for GDI
-            logicalFonts = new Dictionary<string, IntPtr>()
+            fontDescriptors = new()
             {
-                { "H1", createLogicalFont("Roboto Light", 96, MaterialNativeTextRenderer.logFontWeight.FW_LIGHT) },
-                { "H2", createLogicalFont("Roboto Light", 60, MaterialNativeTextRenderer.logFontWeight.FW_LIGHT) },
-                { "H3", createLogicalFont("Roboto", 48, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-                { "H4", createLogicalFont("Roboto", 34, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-                { "H5", createLogicalFont("Roboto", 24, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-                { "H6", createLogicalFont("Roboto Medium", 20, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
-                { "Subtitle1", createLogicalFont("Roboto", 16, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-                { "Subtitle2", createLogicalFont("Roboto Medium", 14, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
-                { "SubtleEmphasis", createLogicalFont("Roboto", 12, MaterialNativeTextRenderer.logFontWeight.FW_NORMAL, 1) },
-                { "Body1", createLogicalFont("Roboto", 16, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-                { "Body2", createLogicalFont("Roboto", 14, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-                { "Button", createLogicalFont("Roboto Medium", 14, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
-                { "Caption", createLogicalFont("Roboto", 12, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-                { "Overline", createLogicalFont("Roboto", 10, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-                // Logical fonts for textbox animation
-                { "textBox16", createLogicalFont("Roboto", 16, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-                { "textBox15", createLogicalFont("Roboto", 15, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-                { "textBox14", createLogicalFont("Roboto", 14, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
-                { "textBox13", createLogicalFont("Roboto Medium", 13, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
-                { "textBox12", createLogicalFont("Roboto Medium", 12, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) }
+                { FontType.H1, new FontDescriptor { FaceName = "Roboto Light", PixelSize = 96, Weight = logFontWeight.FW_LIGHT } },
+                { FontType.H2, new FontDescriptor { FaceName = "Roboto Light", PixelSize = 60, Weight = logFontWeight.FW_LIGHT } },
+                { FontType.H3, new FontDescriptor { FaceName = "Roboto", PixelSize = 48, Weight = logFontWeight.FW_REGULAR } },
+                { FontType.H4, new FontDescriptor { FaceName = "Roboto", PixelSize = 34, Weight = logFontWeight.FW_REGULAR } },
+                { FontType.H5, new FontDescriptor { FaceName = "Roboto", PixelSize = 24, Weight = logFontWeight.FW_REGULAR } },
+                { FontType.H6, new FontDescriptor { FaceName = "Roboto Medium", PixelSize = 20, Weight = logFontWeight.FW_MEDIUM } },
+
+                { FontType.Subtitle1, new FontDescriptor { FaceName = "Roboto", PixelSize = 16, Weight = logFontWeight.FW_REGULAR } },
+                { FontType.Subtitle2, new FontDescriptor { FaceName = "Roboto Medium", PixelSize = 14, Weight = logFontWeight.FW_MEDIUM } },
+                { FontType.SubtleEmphasis, new FontDescriptor { FaceName = "Roboto", PixelSize = 12, Weight = logFontWeight.FW_NORMAL, Italic = 1 } },
+
+                { FontType.Body1, new FontDescriptor { FaceName = "Roboto", PixelSize = 16, Weight = logFontWeight.FW_REGULAR } },
+                { FontType.Body2, new FontDescriptor { FaceName = "Roboto", PixelSize = 14, Weight = logFontWeight.FW_REGULAR } },
+
+                { FontType.Button, new FontDescriptor { FaceName = "Roboto Medium", PixelSize = 14, Weight = logFontWeight.FW_MEDIUM } },
+                { FontType.Caption, new FontDescriptor { FaceName = "Roboto", PixelSize = 12, Weight = logFontWeight.FW_REGULAR } },
+                { FontType.Overline, new FontDescriptor { FaceName = "Roboto", PixelSize = 10, Weight = logFontWeight.FW_REGULAR } },
             };
+
+
+            // create and save font handles for GDI
+            logicalFonts = new Dictionary<string, IntPtr>();
+            //{
+            //    { "H1", createLogicalFont("Roboto Light", 96, MaterialNativeTextRenderer.logFontWeight.FW_LIGHT) },
+            //    { "H2", createLogicalFont("Roboto Light", 60, MaterialNativeTextRenderer.logFontWeight.FW_LIGHT) },
+            //    { "H3", createLogicalFont("Roboto", 48, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
+            //    { "H4", createLogicalFont("Roboto", 34, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
+            //    { "H5", createLogicalFont("Roboto", 24, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
+            //    { "H6", createLogicalFont("Roboto Medium", 20, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
+            //    { "Subtitle1", createLogicalFont("Roboto", 16, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
+            //    { "Subtitle2", createLogicalFont("Roboto Medium", 14, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
+            //    { "SubtleEmphasis", createLogicalFont("Roboto", 12, MaterialNativeTextRenderer.logFontWeight.FW_NORMAL, 1) },
+            //    { "Body1", createLogicalFont("Roboto", 16, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
+            //    { "Body2", createLogicalFont("Roboto", 14, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
+            //    { "Button", createLogicalFont("Roboto Medium", 14, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
+            //    { "Caption", createLogicalFont("Roboto", 12, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
+            //    { "Overline", createLogicalFont("Roboto", 10, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
+            //    // Logical fonts for textbox animation
+            //    { "textBox16", createLogicalFont("Roboto", 16, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
+            //    { "textBox15", createLogicalFont("Roboto", 15, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
+            //    { "textBox14", createLogicalFont("Roboto", 14, MaterialNativeTextRenderer.logFontWeight.FW_REGULAR) },
+            //    { "textBox13", createLogicalFont("Roboto Medium", 13, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) },
+            //    { "textBox12", createLogicalFont("Roboto Medium", 12, MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM) }
+            //};
         }
 
         // Destructor
@@ -327,85 +385,130 @@ namespace ReaLTaiizor.Manager
 
         public IntPtr GetTextBoxFontBySize(int size)
         {
-            string name = "textBox" + Math.Min(16, Math.Max(12, size)).ToString();
-            return logicalFonts[name];
+            return GetTextBoxFontBySize(size, 1f);
+            //string name = "textBox" + Math.Min(16, Math.Max(12, size)).ToString();
+            //return logicalFonts[name];
         }
 
         public IntPtr GetTextBoxFontBySize(int size, float scaleRatio)
         {
             int scaleKey = (int)Math.Round(scaleRatio * 100);
-            string key = "textBox" + Math.Min(16, Math.Max(12, size)).ToString() + "-scale" + scaleKey;
-            if (logicalFonts.TryGetValue(key, out IntPtr existingFont))
+            string cacheKey = $"TextBox-{size}-scale{scaleKey}";
+
+            if (logicalFonts.TryGetValue(cacheKey, out IntPtr cached))
             {
-                return existingFont;
+                return cached;
             }
+
             lock (_fontLock)
             {
-                if (logicalFonts.TryGetValue(key, out IntPtr h))
+                if (logicalFonts.TryGetValue(cacheKey, out cached))
                 {
-                    return h;
+                    return cached;
                 }
 
-                IntPtr hOriginalFont = GetTextBoxFontBySize(size);
-                if (scaleKey == 100)
-                {
-                    return hOriginalFont;
-                }
-
-                try
-                {
-                    using Font originalFont = Font.FromHfont(hOriginalFont);
-                    float scaledSize = originalFont.Size * (float)scaleRatio;
-                    using Font scaledFont = new(originalFont.FontFamily, scaledSize, originalFont.Style, originalFont.Unit);
-                    IntPtr createdFont = scaledFont.ToHfont();
-                    logicalFonts.Add(key, createdFont);
-                    return createdFont;
-                }
-                catch
-                {
-                    return IntPtr.Zero; // Failed fetching handle or creating scaled font
-                }
+                FontDescriptor descriptor = CreateTextBoxDescriptor(size);
+                IntPtr hFont = descriptor.Create(scaleRatio);
+                logicalFonts[cacheKey] = hFont;
+                return hFont;
             }
+
+            //int scaleKey = (int)Math.Round(scaleRatio * 100);
+            //string key = "textBox" + Math.Min(16, Math.Max(12, size)).ToString() + "-scale" + scaleKey;
+            //if (logicalFonts.TryGetValue(key, out IntPtr existingFont))
+            //{
+            //    return existingFont;
+            //}
+            //lock (_fontLock)
+            //{
+            //    if (logicalFonts.TryGetValue(key, out IntPtr h))
+            //    {
+            //        return h;
+            //    }
+
+            //    IntPtr hOriginalFont = GetTextBoxFontBySize(size);
+            //    if (scaleKey == 100)
+            //    {
+            //        return hOriginalFont;
+            //    }
+
+            //    try
+            //    {
+            //        using Font originalFont = Font.FromHfont(hOriginalFont);
+            //        float scaledSize = originalFont.Size * (float)scaleRatio;
+            //        using Font scaledFont = new(originalFont.FontFamily, scaledSize, originalFont.Style, originalFont.Unit);
+            //        IntPtr createdFont = scaledFont.ToHfont();
+            //        logicalFonts.Add(key, createdFont);
+            //        return createdFont;
+            //    }
+            //    catch
+            //    {
+            //        return IntPtr.Zero; // Failed fetching handle or creating scaled font
+            //    }
+            //}
         }
 
         public IntPtr GetLogFontByType(FontType type)
         {
-            return logicalFonts[System.Enum.GetName(typeof(FontType), type)];
+            return GetLogFontByType(type, 1f);
+        
+            //return logicalFonts[System.Enum.GetName(typeof(FontType), type)];
         }
 
         public IntPtr GetLogFontByType(FontType type, float scaleRatio)
         {
             int scaleKey = (int)Math.Round(scaleRatio * 100);
-            string key = System.Enum.GetName(typeof(FontType), type) + "-scale" + scaleKey;
-            if (logicalFonts.TryGetValue(key, out IntPtr existingFont))
+            string cacheKey = $"{type}-scale{scaleKey}";
+
+            if (logicalFonts.TryGetValue(cacheKey, out IntPtr cached))
             {
-                return existingFont;
+                return cached;
             }
+
             lock (_fontLock)
             {
-                if (logicalFonts.TryGetValue(key, out IntPtr cachedFont))
+                if (logicalFonts.TryGetValue(cacheKey, out cached))
                 {
-                    return cachedFont;
-                }
-                IntPtr hOriginalFont = logicalFonts[System.Enum.GetName(typeof(FontType), type)];
-                if (Math.Abs(scaleRatio - 1f) < 0.0001f)
-                {
-                    return hOriginalFont;
+                    return cached;
                 }
 
-                LogFont lf = new();
-                if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0) return IntPtr.Zero; // Failed fetching handle
-                IntPtr createdFont = createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(), lf.lfWeight), lfItalic: lf.lfItalic);
-                logicalFonts.Add(key, createdFont);
-                return createdFont;
-
-                //using Font originalFont = Font.FromHfont(hOriginalFont);
-                //float newSize = originalFont.Size * (float)scaleRatio;
-                //using Font scaledFont = new(originalFont.FontFamily, newSize, originalFont.Style, originalFont.Unit);
-                //IntPtr createdFont = scaledFont.ToHfont();
-                //logicalFonts.Add(key, createdFont);
-                //return createdFont;
+                FontDescriptor descriptor = fontDescriptors[type];
+                IntPtr hFont = descriptor.Create(scaleRatio);
+                logicalFonts[cacheKey] = hFont;
+                return hFont;
             }
+
+            //int scaleKey = (int)Math.Round(scaleRatio * 100);
+            //string key = System.Enum.GetName(typeof(FontType), type) + "-scale" + scaleKey;
+            //if (logicalFonts.TryGetValue(key, out IntPtr existingFont))
+            //{
+            //    return existingFont;
+            //}
+            //lock (_fontLock)
+            //{
+            //    if (logicalFonts.TryGetValue(key, out IntPtr cachedFont))
+            //    {
+            //        return cachedFont;
+            //    }
+            //    IntPtr hOriginalFont = logicalFonts[System.Enum.GetName(typeof(FontType), type)];
+            //    if (Math.Abs(scaleRatio - 1f) < 0.0001f)
+            //    {
+            //        return hOriginalFont;
+            //    }
+
+            //    LogFont lf = new();
+            //    if (GetObject(hOriginalFont, Marshal.SizeOf(lf), lf) == 0) return IntPtr.Zero; // Failed fetching handle
+            //    IntPtr createdFont = createLogicalFont(lf.lfFaceName, (int)(-lf.lfHeight * scaleRatio), (logFontWeight)System.Enum.ToObject(MaterialNativeTextRenderer.logFontWeight.FW_MEDIUM.GetType(), lf.lfWeight), lfItalic: lf.lfItalic);
+            //    logicalFonts.Add(key, createdFont);
+            //    return createdFont;
+
+            //    //using Font originalFont = Font.FromHfont(hOriginalFont);
+            //    //float newSize = originalFont.Size * (float)scaleRatio;
+            //    //using Font scaledFont = new(originalFont.FontFamily, newSize, originalFont.Style, originalFont.Unit);
+            //    //IntPtr createdFont = scaledFont.ToHfont();
+            //    //logicalFonts.Add(key, createdFont);
+            //    //return createdFont;
+            //}
         }
 
         // Font stuff
@@ -430,7 +533,7 @@ namespace ReaLTaiizor.Manager
             privateFontCollection.AddMemoryFont(ptrFont, dataLength);
         }
 
-        private IntPtr createLogicalFont(string fontName, int size, MaterialNativeTextRenderer.logFontWeight weight, byte lfItalic = 0)
+        private static IntPtr createLogicalFont(string fontName, int size, MaterialNativeTextRenderer.logFontWeight weight, byte lfItalic = 0)
         {
             // Logical font:
             MaterialNativeTextRenderer.LogFont lfont = new()
@@ -552,9 +655,6 @@ namespace ReaLTaiizor.Manager
                 }
             }
         }
-
-        [DllImport("gdi32.dll", CharSet = CharSet.Auto)]
-        public static extern int GetObject(IntPtr hFont, int nSize, [In, Out] LogFont lf);
 
     }
 

--- a/src/ReaLTaiizor/ReaLTaiizor.cs
+++ b/src/ReaLTaiizor/ReaLTaiizor.cs
@@ -13,7 +13,7 @@ using System.Windows.Forms;
 //     Creator: Taiizor
 //     Website: www.vegalya.com
 //     Created: 15.May.2019
-//     Changed: 06.Feb.2026
+//     Changed: 18.Feb.2026
 //     Version: 3.8.1.6
 //
 // |---------DO-NOT-REMOVE---------|

--- a/src/ReaLTaiizor/ReaLTaiizor.cs
+++ b/src/ReaLTaiizor/ReaLTaiizor.cs
@@ -13,7 +13,7 @@ using System.Windows.Forms;
 //     Creator: Taiizor
 //     Website: www.vegalya.com
 //     Created: 15.May.2019
-//     Changed: 04.Feb.2026
+//     Changed: 06.Feb.2026
 //     Version: 3.8.1.6
 //
 // |---------DO-NOT-REMOVE---------|


### PR DESCRIPTION
## An error occurred after applying Copilot suggestions removing unmanaged code

<img width="3199" height="1999" alt="image" src="https://github.com/user-attachments/assets/c1efc503-69c3-4751-8d34-1c6b556c7911" />

Since there is no TTF font for this method, it would throw a fatal exception and the window would crash. In previous version of this method, an unmanaged method is used to process the scaling logic, since we cannot fetch font details in assigned ways and informations are sealed in magic-numbers-based dictionary.

However, after simulating the executing logic, I am here to provide a new way to avoid the problem. With the introduction of a new Descriptor class, fonts' information is now accessible in scaling process, without applying unmanaged codes.
<img width="1719" height="1067" alt="image" src="https://github.com/user-attachments/assets/80bea0ee-6e5f-4d89-a4bd-0aaba4cfefcc" />
<img width="1535" height="1063" alt="image" src="https://github.com/user-attachments/assets/d3e1729e-1ed7-4f9f-a1d0-b18caf95e899" />

After tests on High-DPI devices, now these methods can process without exceptions. TextBoxes are also included in this new logic and they work well.
Please consider these codes if they can help, and any improvements and suggestions are welcomed! :-)

#### Commit Notes:
Removed unmanaged code with re-constructed non-magical methods. No exceptions occurred in tests.
- Replaced Magic-numbers based Lfont dictionary into reusable ones. Original Lfont cannot be modified or re-created without a GetObject, but now we can use direct font details instead.
- Supported Textbox dynamic font requirements.
- Other fixes.
This push uses GPT-5.2 to complete complex and repeating re-constructing process. And with unmanaged code removed and DPI-scaling environment tested, it can now be merged cleanly.